### PR TITLE
EVG-12770: warn instead of error on 413

### DIFF
--- a/views.go
+++ b/views.go
@@ -231,7 +231,7 @@ func (lk *logKeeper) appendLog(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	if err := lk.checkContentLength(r); err != nil {
-		lk.logWarningf(r, "content length limit exceeded for appendLog: %s", err.Err)
+		lk.logErrorf(r, "content length limit exceeded for appendLog: %s", err.Err)
 		lk.render.WriteJSON(w, err.code, err)
 		return
 	}
@@ -322,7 +322,7 @@ func (lk *logKeeper) appendGlobalLog(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	if err := lk.checkContentLength(r); err != nil {
-		lk.logErrorf(r, "content length limit exceeded for appendGlobalLog: %s", err.Err)
+		lk.logWarningf(r, "content length limit exceeded for appendGlobalLog: %s", err.Err)
 		lk.render.WriteJSON(w, err.code, err)
 		return
 	}

--- a/views.go
+++ b/views.go
@@ -231,7 +231,7 @@ func (lk *logKeeper) appendLog(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	if err := lk.checkContentLength(r); err != nil {
-		lk.logErrorf(r, "content length limit exceeded for appendLog: %s", err.Err)
+		lk.logWarningf(r, "content length limit exceeded for appendLog: %s", err.Err)
 		lk.render.WriteJSON(w, err.code, err)
 		return
 	}
@@ -656,6 +656,14 @@ func (lk *logKeeper) findGlobalLogsDuringTest(build *LogKeeperBuild, test *Test)
 func (lk *logKeeper) logErrorf(r *http.Request, format string, v ...interface{}) {
 	err := fmt.Sprintf(format, v...)
 	grip.Error(message.Fields{
+		"request": GetCtxRequestId(r),
+		"error":   err,
+	})
+}
+
+func (lk *logKeeper) logWarningf(r *http.Request, format string, v ...interface{}) {
+	err := fmt.Sprintf(format, v...)
+	grip.Warning(message.Fields{
 		"request": GetCtxRequestId(r),
 		"error":   err,
 	})


### PR DESCRIPTION

decrease logging level for content length limit exceeded for appendGlobalLog errors