### PR TITLE
EVG-14250 allow all origins on GETs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 logkeeper
 build/*
 fabfile.py
+fab_common.py
 *.pyc
 buildscripts/.lobster-temp/
 logkeeperapp.log

--- a/views.go
+++ b/views.go
@@ -408,6 +408,7 @@ func (lk *logKeeper) appendGlobalLog(w http.ResponseWriter, r *http.Request) {
 }
 
 func (lk *logKeeper) viewBuildById(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Access-Control-Allow-Origin", "*")
 	defer r.Body.Close()
 
 	vars := mux.Vars(r)
@@ -440,6 +441,7 @@ func (lk *logKeeper) viewBuildById(w http.ResponseWriter, r *http.Request) {
 }
 
 func (lk *logKeeper) viewAllLogs(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Access-Control-Allow-Origin", "*")
 	defer r.Body.Close()
 
 	vars := mux.Vars(r)
@@ -486,6 +488,7 @@ func (lk *logKeeper) viewAllLogs(w http.ResponseWriter, r *http.Request) {
 }
 
 func (lk *logKeeper) viewTestByBuildIdTestId(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Access-Control-Allow-Origin", "*")
 	defer r.Body.Close()
 
 	vars := mux.Vars(r)
@@ -554,6 +557,7 @@ func (lk *logKeeper) viewTestByBuildIdTestId(w http.ResponseWriter, r *http.Requ
 }
 
 func (lk *logKeeper) viewInLobster(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Access-Control-Allow-Origin", "*")
 	err := lk.render.StreamHTML(w, http.StatusOK, nil, "base", "lobster/build/index.html")
 	if err != nil {
 		lk.logErrorf(r, "Error rendering template: %v", err)


### PR DESCRIPTION
I went with the low-effort approach of allowing all origins because we don't have any authentication system, so trying to control origins is kind of a moot point