### PR TITLE
EVG-17145 reapply stats cache

### DIFF
--- a/background.go
+++ b/background.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/evergreen-ci/logkeeper/db"
+	"github.com/evergreen-ci/logkeeper/env"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/recovery"
@@ -29,7 +29,7 @@ func StartBackgroundLogging(ctx context.Context) {
 				if IsLeader() {
 					grip.Info(message.Fields{
 						"message": "amboy queue stats",
-						"stats":   db.GetCleanupQueue().Stats(ctx),
+						"stats":   env.CleanupQueue().Stats(ctx),
 					})
 				}
 

--- a/db/db.go
+++ b/db/db.go
@@ -1,94 +1,14 @@
 package db
 
 import (
-	"context"
-	"sync"
-
-	"github.com/mongodb/amboy"
-	"github.com/pkg/errors"
+	"github.com/evergreen-ci/logkeeper/env"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-type sessionCache struct {
-	client *mongo.Client
-	ctx    context.Context
-	dbName string
-
-	cleanupQueue amboy.Queue
-
-	sync.RWMutex
-}
-
-var session *sessionCache
-
-func init() {
-	session = &sessionCache{}
-}
-
-func SetContext(ctx context.Context) {
-	session.Lock()
-	defer session.Unlock()
-
-	session.ctx = ctx
-}
-
-func Context() context.Context {
-	session.RLock()
-	defer session.RUnlock()
-
-	return session.ctx
-}
-
-func Client() *mongo.Client {
-	session.RLock()
-	defer session.RUnlock()
-
-	return session.client
-}
-
-func SetClient(c *mongo.Client) {
-	session.Lock()
-	defer session.Unlock()
-
-	session.client = c
-}
-
 func DB() *mongo.Database {
-	session.RLock()
-	defer session.RUnlock()
-
-	return session.client.Database(session.dbName)
+	return env.Client().Database(env.DBName())
 }
 
 func C(collectionName string) *mongo.Collection {
-	session.RLock()
-	defer session.RUnlock()
-
-	return session.client.Database(session.dbName).Collection(collectionName)
-}
-
-func SetDBName(name string) {
-	session.Lock()
-	defer session.Unlock()
-
-	session.dbName = name
-}
-
-func SetCleanupQueue(q amboy.Queue) error {
-	if !q.Info().Started {
-		return errors.New("queue isn't started")
-	}
-
-	session.Lock()
-	defer session.Unlock()
-
-	session.cleanupQueue = q
-	return nil
-}
-
-func GetCleanupQueue() amboy.Queue {
-	session.RLock()
-	defer session.RUnlock()
-
-	return session.cleanupQueue
+	return env.Client().Database(env.DBName()).Collection(collectionName)
 }

--- a/env/env.go
+++ b/env/env.go
@@ -1,0 +1,112 @@
+package env
+
+import (
+	"context"
+	"sync"
+
+	"github.com/mongodb/amboy"
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type environment struct {
+	ctx    context.Context
+	client *mongo.Client
+	dbName string
+
+	cleanupQueue amboy.Queue
+	stats        *statsCache
+
+	sync.RWMutex
+}
+
+var globalEnv *environment
+
+func init() {
+	globalEnv = &environment{}
+}
+
+// SetContext caches a context to be available from the environment.
+func SetContext(ctx context.Context) {
+	globalEnv.Lock()
+	defer globalEnv.Unlock()
+
+	globalEnv.ctx = ctx
+}
+
+// Context returns the cached context from the environment.
+func Context() context.Context {
+	globalEnv.RLock()
+	defer globalEnv.RUnlock()
+
+	return globalEnv.ctx
+}
+
+// SetClient caches a Mongo Client to be available from the environment.
+func SetClient(c *mongo.Client) {
+	globalEnv.Lock()
+	defer globalEnv.Unlock()
+
+	globalEnv.client = c
+}
+
+// Client returns the cached Mongo Client from the environment.
+func Client() *mongo.Client {
+	globalEnv.RLock()
+	defer globalEnv.RUnlock()
+
+	return globalEnv.client
+}
+
+// SetDBName caches a DB name to be available from the environment.
+func SetDBName(name string) {
+	globalEnv.Lock()
+	defer globalEnv.Unlock()
+
+	globalEnv.dbName = name
+}
+
+// DBName returns the cached DB name from the environment.
+func DBName() string {
+	globalEnv.RLock()
+	defer globalEnv.RUnlock()
+
+	return globalEnv.dbName
+}
+
+// SetStatsCache caches a stats cache to be available from the environment.
+func SetStatsCache(s *statsCache) {
+	globalEnv.Lock()
+	defer globalEnv.Unlock()
+
+	globalEnv.stats = s
+}
+
+// StatsCache returns the cached stats cache from the environment.
+func StatsCache() *statsCache {
+	globalEnv.RLock()
+	defer globalEnv.RUnlock()
+
+	return globalEnv.stats
+}
+
+// SetCleanupQueue caches the cleanup queue to be available from the environment.
+func SetCleanupQueue(q amboy.Queue) error {
+	if !q.Info().Started {
+		return errors.New("queue isn't started")
+	}
+
+	globalEnv.Lock()
+	defer globalEnv.Unlock()
+
+	globalEnv.cleanupQueue = q
+	return nil
+}
+
+// CleanupQueue returns the cached cleanup queue from the environment.
+func CleanupQueue() amboy.Queue {
+	globalEnv.RLock()
+	defer globalEnv.RUnlock()
+
+	return globalEnv.cleanupQueue
+}

--- a/env/stats_cache.go
+++ b/env/stats_cache.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	statChanBufferSize = 1000
+	sizesLimit         = 100000
 	logInterval        = 10 * time.Second
 	bytesPerMB         = 1000000
 )
@@ -133,6 +134,12 @@ func (s *statsCache) loggerLoop(ctx context.Context) {
 			s.resetCache()
 		case applyChange := <-s.changeChan:
 			applyChange(s)
+
+			if len(s.logMBs) >= sizesLimit {
+				s.logStats()
+				s.resetCache()
+				ticker.Reset(logInterval)
+			}
 		}
 	}
 }

--- a/env/stats_cache.go
+++ b/env/stats_cache.go
@@ -1,0 +1,149 @@
+package env
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/recovery"
+	"gonum.org/v1/gonum/floats"
+	"gonum.org/v1/gonum/stat"
+)
+
+const (
+	statChanBufferSize = 1000
+	logInterval        = 10 * time.Second
+	bytesPerMB         = 1000000
+)
+
+var histogramDividers = []float64{0, 0.5, 1, 5, 10, 40}
+
+type statsCache struct {
+	buildsCreated int
+	testsCreated  int
+	logMBs        []float64
+
+	buildsAccessed       int
+	allBuildLogsAccessed int
+	testLogsAccessed     int
+
+	changeChan chan func(*statsCache)
+	lastReset  time.Time
+}
+
+// BuildCreated records that a build has been created.
+// Returns an error if events are enqueued faster than the cache can process them.
+func (s *statsCache) BuildCreated() error {
+	return s.enqueueChange(func(s *statsCache) { s.buildsCreated++ })
+}
+
+// TestCreated records that a test has been created.
+// Returns an error if events are enqueued faster than the cache can process them.
+func (s *statsCache) TestCreated() error {
+	return s.enqueueChange(func(s *statsCache) { s.testsCreated++ })
+}
+
+// LogAppended records that a log has been appended.
+// Returns an error if events are enqueued faster than the cache can process them.
+func (s *statsCache) LogAppended(numBytes int) error {
+	return s.enqueueChange(func(s *statsCache) { s.logMBs = append(s.logMBs, float64(numBytes)/bytesPerMB) })
+}
+
+// BuildAccessed records that a build has been accessed.
+// Returns an error if events are enqueued faster than the cache can process them.
+func (s *statsCache) BuildAccessed() error {
+	return s.enqueueChange(func(s *statsCache) { s.buildsAccessed++ })
+}
+
+// TestLogsAccessed records that a test's logs have been accessed.
+// Returns an error if events are enqueued faster than the cache can process them.
+func (s *statsCache) TestLogsAccessed() error {
+	return s.enqueueChange(func(s *statsCache) { s.testLogsAccessed++ })
+}
+
+// AllLogsAccessed records that all of a build's logs have been accessed.
+// Returns an error if events are enqueued faster than the cache can process them.
+func (s *statsCache) AllLogsAccessed() error {
+	return s.enqueueChange(func(s *statsCache) { s.allBuildLogsAccessed++ })
+}
+
+func (s *statsCache) enqueueChange(change func(*statsCache)) error {
+	select {
+	case s.changeChan <- change:
+		return nil
+	default:
+		return errors.New("incoming stats buffer is full")
+	}
+}
+
+func (s *statsCache) logStats() {
+	stats := message.Fields{
+		"message":                     "usage stats",
+		"interval_ms":                 time.Since(s.lastReset).Milliseconds(),
+		"num_builds_created":          s.buildsCreated,
+		"num_tests_created":           s.testsCreated,
+		"num_appends":                 len(s.logMBs),
+		"num_builds_accessed":         s.buildsAccessed,
+		"num_all_build_logs_accessed": s.allBuildLogsAccessed,
+		"num_test_logs_accessed":      s.testLogsAccessed,
+	}
+	if len(s.logMBs) > 0 {
+		stats["append_size_total"] = floats.Sum(s.logMBs)
+		stats["append_size_min"] = floats.Min(s.logMBs)
+		stats["append_size_max"] = floats.Max(s.logMBs)
+		stats["append_size_mean"] = stat.Mean(s.logMBs, nil)
+		stats["append_size_stddev"] = stat.StdDev(s.logMBs, nil)
+		stats["histogram"] = stat.Histogram(nil, histogramDividers, s.logMBs, nil)
+	}
+	grip.Info(stats)
+}
+
+func (s *statsCache) resetCache() {
+	s.buildsCreated = 0
+	s.testsCreated = 0
+	s.logMBs = s.logMBs[:0]
+
+	s.buildsAccessed = 0
+	s.allBuildLogsAccessed = 0
+	s.testLogsAccessed = 0
+
+	s.lastReset = time.Now()
+}
+
+func (s *statsCache) loggerLoop(ctx context.Context) {
+	defer func() {
+		if err := recovery.HandlePanicWithError(recover(), nil, "stats cache logger"); err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": "panic in stats cache logger loop",
+			}))
+		}
+	}()
+
+	ticker := time.NewTicker(logInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.logStats()
+			s.resetCache()
+		case applyChange := <-s.changeChan:
+			applyChange(s)
+		}
+	}
+}
+
+// NewStatsCache returns an initialized stats cache and begins processing incoming events.
+func NewStatsCache(ctx context.Context) *statsCache {
+	cache := statsCache{
+		lastReset:  time.Now(),
+		changeChan: make(chan func(*statsCache), statChanBufferSize),
+	}
+	go cache.loggerLoop(ctx)
+
+	return &cache
+}

--- a/env/stats_cache_test.go
+++ b/env/stats_cache_test.go
@@ -1,0 +1,102 @@
+package env
+
+import (
+	"testing"
+
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/send"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func TestLoggerLoop(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*logInterval)
+	defer cancel()
+	defer grip.SetSender(grip.GetSender())
+
+	cache := NewStatsCache(ctx)
+	for testName, testCase := range map[string]struct {
+		mutator func() error
+		field   string
+	}{
+		"BuildCreated":    {mutator: cache.BuildCreated, field: "num_builds_created"},
+		"TestCreated":     {mutator: cache.TestCreated, field: "num_tests_created"},
+		"Append":          {mutator: func() error { return cache.LogAppended(5) }, field: "num_appends"},
+		"BuildsAccessed":  {mutator: cache.BuildAccessed, field: "num_builds_accessed"},
+		"TestLogAccessed": {mutator: cache.TestLogsAccessed, field: "num_test_logs_accessed"},
+		"AllLogsAccessed": {mutator: cache.AllLogsAccessed, field: "num_all_build_logs_accessed"},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			sender := send.NewMockSender("")
+			grip.SetSender(sender)
+
+			assert.NoError(t, testCase.mutator())
+
+			require.Eventually(t, func() bool { return len(sender.Messages) > 0 }, 2*logInterval, logInterval/2)
+			msg := sender.Messages[0].Raw().(message.Fields)
+			for _, field := range []string{
+				"num_builds_created",
+				"num_tests_created",
+				"num_appends",
+				"num_builds_accessed",
+				"num_all_build_logs_accessed",
+				"num_test_logs_accessed",
+			} {
+				if field == testCase.field {
+					assert.Equal(t, 1, msg[field])
+				} else {
+					assert.Equal(t, 0, msg[field])
+				}
+			}
+		})
+	}
+}
+
+func TestChannelFull(t *testing.T) {
+	defer grip.SetSender(grip.GetSender())
+	sender := send.NewMockSender("")
+	grip.SetSender(sender)
+
+	cache := statsCache{changeChan: make(chan func(*statsCache), 5)}
+	for x := 0; x < 5; x++ {
+		cache.BuildCreated()
+	}
+	assert.Len(t, sender.Messages, 0)
+
+	assert.Error(t, cache.BuildCreated())
+}
+
+func TestLogSizeStats(t *testing.T) {
+	defer grip.SetSender(grip.GetSender())
+
+	t.Run("WithValues", func(t *testing.T) {
+		sender := send.NewMockSender("")
+		grip.SetSender(sender)
+
+		cache := statsCache{
+			logMBs: []float64{0, 15, 30},
+		}
+		cache.logStats()
+
+		require.Len(t, sender.Messages, 1)
+		msg := sender.Messages[0].Raw().(message.Fields)
+		assert.EqualValues(t, 45, msg["append_size_total"])
+		assert.EqualValues(t, 0, msg["append_size_min"])
+		assert.EqualValues(t, 30, msg["append_size_max"])
+		assert.EqualValues(t, 15, msg["append_size_mean"])
+		assert.EqualValues(t, 15, msg["append_size_stddev"])
+		assert.Equal(t, []float64{1, 0, 0, 0, 2}, msg["histogram"])
+	})
+	t.Run("WithoutValues", func(t *testing.T) {
+		sender := send.NewMockSender("")
+		grip.SetSender(sender)
+
+		cache := statsCache{}
+		cache.logStats()
+		require.Len(t, sender.Messages, 1)
+		_, ok := sender.Messages[0].Raw().(message.Fields)["append_size_min"]
+		assert.False(t, ok)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -21,4 +21,5 @@ require (
 	github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff // indirect
 	github.com/jacobsa/ogletest v0.0.0-20170503003838-80d50a735a11 // indirect
 	github.com/jacobsa/reqtrace v0.0.0-20150505043853-245c9e0234cb // indirect
+	gonum.org/v1/gonum v0.11.0
 )

--- a/logkeeper_test.go
+++ b/logkeeper_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/logkeeper/db"
+	"github.com/evergreen-ci/logkeeper/env"
 	"github.com/mongodb/grip"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/smartystreets/goconvey/convey/reporting"
@@ -21,7 +22,7 @@ import (
 )
 
 func resetDatabase() {
-	grip.Error(db.DB().Drop(db.Context()))
+	grip.Error(db.DB().Drop(env.Context()))
 }
 
 func init() {
@@ -75,18 +76,18 @@ func TestLogKeeper(t *testing.T) {
 
 			// Test should have seq = 2
 			test := &Test{}
-			err = db.C("tests").FindOne(db.Context(), bson.M{"_id": testObjectID}).Decode(test)
+			err = db.C("tests").FindOne(env.Context(), bson.M{"_id": testObjectID}).Decode(test)
 			So(err, ShouldBeNil)
 			So(test.Seq, ShouldEqual, 2)
 
 			// Test should have two logs
-			numLogs, err := db.C("logs").CountDocuments(db.Context(), bson.M{"test_id": testObjectID})
+			numLogs, err := db.C("logs").CountDocuments(env.Context(), bson.M{"test_id": testObjectID})
 			So(err, ShouldBeNil)
 			So(numLogs, ShouldEqual, 2)
 
 			// First log should have two lines and seq=1
 			// Second log should have one line and seq=2
-			cur, err := db.C("logs").Find(db.Context(), bson.M{"test_id": testObjectID}, options.Find().SetSort(bson.M{"seq": 1}))
+			cur, err := db.C("logs").Find(env.Context(), bson.M{"test_id": testObjectID}, options.Find().SetSort(bson.M{"seq": 1}))
 			So(err, ShouldBeNil)
 			firstLog := true
 			for cur.Next(ctx) {
@@ -103,7 +104,7 @@ func TestLogKeeper(t *testing.T) {
 				}
 			}
 
-			So(db.DB().Drop(db.Context()), ShouldBeNil)
+			So(db.DB().Drop(env.Context()), ShouldBeNil)
 
 			// Create build
 			r = newTestRequest(lk, "POST", "/build", map[string]interface{}{"builder": "myBuilder", "buildnum": 123})
@@ -118,18 +119,18 @@ func TestLogKeeper(t *testing.T) {
 
 			// Build should have seq = 2
 			build := &LogKeeperBuild{}
-			err = db.C("builds").FindOne(db.Context(), bson.M{"_id": buildId}).Decode(build)
+			err = db.C("builds").FindOne(env.Context(), bson.M{"_id": buildId}).Decode(build)
 			So(err, ShouldBeNil)
 			So(build.Seq, ShouldEqual, 2)
 
 			// Build should have two logs
-			numLogs, err = db.C("logs").CountDocuments(db.Context(), bson.M{"build_id": buildId})
+			numLogs, err = db.C("logs").CountDocuments(env.Context(), bson.M{"build_id": buildId})
 			So(err, ShouldBeNil)
 			So(numLogs, ShouldEqual, 2)
 
 			// First log should have two lines and seq=1
 			// Second log should have one line and seq=2
-			cur, err = db.C("logs").Find(db.Context(), bson.M{"build_id": buildId}, options.Find().SetSort(bson.M{"seq": 1}))
+			cur, err = db.C("logs").Find(env.Context(), bson.M{"build_id": buildId}, options.Find().SetSort(bson.M{"seq": 1}))
 			So(err, ShouldBeNil)
 			firstLog = true
 			for cur.Next(ctx) {
@@ -169,7 +170,7 @@ func TestLogKeeper(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			test := &Test{}
-			err = db.C("tests").FindOne(db.Context(), bson.M{"_id": testObjectID}).Decode(test)
+			err = db.C("tests").FindOne(env.Context(), bson.M{"_id": testObjectID}).Decode(test)
 			So(err, ShouldBeNil)
 			So(test.Info, ShouldNotBeNil)
 			So(test.Info["task_id"], ShouldEqual, "abc123")

--- a/main/logkeeper.go
+++ b/main/logkeeper.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/logkeeper"
-	"github.com/evergreen-ci/logkeeper/db"
+	"github.com/evergreen-ci/logkeeper/env"
 	"github.com/evergreen-ci/logkeeper/units"
 	gorillaCtx "github.com/gorilla/context"
 	"github.com/mongodb/amboy/pool"
@@ -54,9 +54,11 @@ func main() {
 	grip.EmergencyFatal(errors.Wrap(err, "constructing worker pool"))
 	grip.EmergencyFatal(cleanupQueue.SetRunner(runner))
 	grip.EmergencyFatal(cleanupQueue.Start(ctx))
-	grip.EmergencyFatal(db.SetCleanupQueue(cleanupQueue))
+	grip.EmergencyFatal(env.SetCleanupQueue(cleanupQueue))
 
 	grip.EmergencyFatal(units.StartCleanupCron(ctx, cleanupQueue))
+
+	env.SetStatsCache(env.NewStatsCache(ctx))
 
 	lk := logkeeper.New(logkeeper.Options{
 		URL:            fmt.Sprintf("http://localhost:%v", *httpPort),
@@ -171,9 +173,9 @@ func initDB(ctx context.Context, dbURI, rsName string, maxPoolSize int) error {
 		return errors.Wrap(err, "connecting to the database")
 	}
 
-	db.SetClient(client)
-	db.SetDBName(logkeeper.DBName)
-	db.SetContext(ctx)
+	env.SetClient(client)
+	env.SetDBName(logkeeper.DBName)
+	env.SetContext(ctx)
 
 	return nil
 }

--- a/schema.go
+++ b/schema.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/logkeeper/db"
+	"github.com/evergreen-ci/logkeeper/env"
 	"github.com/mongodb/grip/recovery"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
@@ -53,7 +54,7 @@ func findTest(id string) (*Test, error) {
 	}
 
 	test := &Test{}
-	if err := db.C(testsCollection).FindOne(db.Context(), bson.M{"_id": objectID}).Decode(test); err != nil {
+	if err := db.C(testsCollection).FindOne(env.Context(), bson.M{"_id": objectID}).Decode(test); err != nil {
 		if err == mongo.ErrNoDocuments {
 			return nil, nil
 		}
@@ -64,13 +65,13 @@ func findTest(id string) (*Test, error) {
 }
 
 func findTestsForBuild(buildID string) ([]Test, error) {
-	cur, err := db.C(testsCollection).Find(db.Context(), bson.M{"build_id": buildID}, options.Find().SetSort(bson.M{"started": 1}))
+	cur, err := db.C(testsCollection).Find(env.Context(), bson.M{"build_id": buildID}, options.Find().SetSort(bson.M{"started": 1}))
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding tests for build '%s'", buildID)
 	}
 
 	var tests []Test
-	if err := cur.All(db.Context(), &tests); err != nil {
+	if err := cur.All(env.Context(), &tests); err != nil {
 		return nil, errors.Wrapf(err, "decoding tests for build '%s'", buildID)
 	}
 
@@ -79,7 +80,7 @@ func findTestsForBuild(buildID string) ([]Test, error) {
 
 func findBuildById(id string) (*LogKeeperBuild, error) {
 	build := &LogKeeperBuild{}
-	if err := db.C(buildsCollection).FindOne(db.Context(), bson.M{"_id": id}).Decode(build); err != nil {
+	if err := db.C(buildsCollection).FindOne(env.Context(), bson.M{"_id": id}).Decode(build); err != nil {
 		if err == mongo.ErrNoDocuments {
 			return nil, nil
 		}
@@ -91,7 +92,7 @@ func findBuildById(id string) (*LogKeeperBuild, error) {
 
 func findBuildByBuilder(builder string, buildnum int) (*LogKeeperBuild, error) {
 	build := &LogKeeperBuild{}
-	if err := db.C(buildsCollection).FindOne(db.Context(), bson.M{"builder": builder, "buildnum": buildnum}).Decode(build); err != nil {
+	if err := db.C(buildsCollection).FindOne(env.Context(), bson.M{"builder": builder, "buildnum": buildnum}).Decode(build); err != nil {
 		if err == mongo.ErrNoDocuments {
 			return nil, nil
 		}
@@ -102,7 +103,7 @@ func findBuildByBuilder(builder string, buildnum int) (*LogKeeperBuild, error) {
 }
 
 func UpdateFailedBuild(id string) error {
-	_, err := db.C(buildsCollection).UpdateByID(db.Context(), id, bson.M{"$set": bson.M{"failed": true}})
+	_, err := db.C(buildsCollection).UpdateByID(env.Context(), id, bson.M{"$set": bson.M{"failed": true}})
 	return errors.Wrapf(err, "setting failed state on build '%s'", id)
 }
 
@@ -122,13 +123,13 @@ func getOldBuildQuery() bson.M {
 }
 
 func GetOldBuilds(limit int) ([]LogKeeperBuild, error) {
-	cur, err := db.C(buildsCollection).Find(db.Context(), getOldBuildQuery(), options.Find().SetLimit(int64(limit)).SetMaxTime(2*AmboyInterval))
+	cur, err := db.C(buildsCollection).Find(env.Context(), getOldBuildQuery(), options.Find().SetLimit(int64(limit)).SetMaxTime(2*AmboyInterval))
 	if err != nil {
 		return nil, errors.Wrap(err, "finding old builds")
 	}
 
 	var builds []LogKeeperBuild
-	if err := cur.All(db.Context(), &builds); err != nil {
+	if err := cur.All(env.Context(), &builds); err != nil {
 		return nil, errors.Wrap(err, "decoding old builds")
 	}
 
@@ -143,14 +144,14 @@ func StreamingGetOldBuilds(ctx context.Context) (<-chan LogKeeperBuild, <-chan e
 		defer close(out)
 		defer recovery.LogStackTraceAndContinue("streaming query")
 
-		cur, err := db.C(buildsCollection).Find(db.Context(), getOldBuildQuery(), options.Find())
+		cur, err := db.C(buildsCollection).Find(env.Context(), getOldBuildQuery(), options.Find())
 		if err != nil {
 			errOut <- err
 			return
 		}
-		defer cur.Close(db.Context())
+		defer cur.Close(env.Context())
 
-		for cur.Next(db.Context()) {
+		for cur.Next(env.Context()) {
 			build := LogKeeperBuild{}
 			if err := cur.Decode(&build); err != nil {
 				errOut <- err
@@ -179,19 +180,19 @@ type CleanupStats struct {
 
 func CleanupOldLogsAndTestsByBuild(id string) (CleanupStats, error) {
 	var stats CleanupStats
-	result, err := db.C(logsCollection).DeleteMany(db.Context(), bson.M{"build_id": id})
+	result, err := db.C(logsCollection).DeleteMany(env.Context(), bson.M{"build_id": id})
 	if err != nil {
 		return stats, errors.Wrap(err, "deleting logs from old builds")
 	}
 	stats.NumLogs += int(result.DeletedCount)
 
-	result, err = db.C(testsCollection).DeleteMany(db.Context(), bson.M{"build_id": id})
+	result, err = db.C(testsCollection).DeleteMany(env.Context(), bson.M{"build_id": id})
 	if err != nil {
 		return stats, errors.Wrap(err, "deleting tests from old builds")
 	}
 	stats.NumTests += int(result.DeletedCount)
 
-	result, err = db.C(buildsCollection).DeleteOne(db.Context(), bson.M{"_id": id})
+	result, err = db.C(buildsCollection).DeleteOne(env.Context(), bson.M{"_id": id})
 	if err != nil {
 		return stats, errors.Wrap(err, "deleting build record")
 	}

--- a/schema_test.go
+++ b/schema_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/logkeeper/db"
+	"github.com/evergreen-ci/logkeeper/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
@@ -19,14 +20,14 @@ func initTestDB(ctx context.Context, t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, client.Connect(ctx))
 
-	db.SetClient(client)
-	db.SetDBName("logkeeper_test")
-	db.SetContext(ctx)
+	env.SetClient(client)
+	env.SetDBName("logkeeper_test")
+	env.SetContext(ctx)
 }
 
 func clearCollections(t *testing.T, collections ...string) {
 	for _, col := range collections {
-		_, err := db.C(col).DeleteMany(db.Context(), bson.M{})
+		_, err := db.C(col).DeleteMany(env.Context(), bson.M{})
 		require.NoError(t, err)
 	}
 }
@@ -58,7 +59,7 @@ func insertBuilds(t *testing.T) []string {
 		Started: now,
 		Info:    info,
 	}
-	_, err := db.C(buildsCollection).InsertMany(db.Context(), []interface{}{oldBuild1, oldBuild2, edgeBuild, newBuild})
+	_, err := db.C(buildsCollection).InsertMany(env.Context(), []interface{}{oldBuild1, oldBuild2, edgeBuild, newBuild})
 	assert.NoError(err)
 	return []string{oldBuild1.Id, oldBuild2.Id, edgeBuild.Id, newBuild.Id}
 }
@@ -82,7 +83,7 @@ func insertTests(t *testing.T, ids []string) {
 		Id:      primitive.NewObjectID(),
 		BuildId: ids[3],
 	}
-	_, err := db.C(testsCollection).InsertMany(db.Context(), []interface{}{test1, test2, test3, test4})
+	_, err := db.C(testsCollection).InsertMany(env.Context(), []interface{}{test1, test2, test3, test4})
 	assert.NoError(err)
 }
 
@@ -94,7 +95,7 @@ func insertLogs(t *testing.T, ids []string) {
 	log3 := Log{BuildId: ids[1]}
 	newId := primitive.NewObjectID().Hex()
 	log4 := Log{BuildId: newId}
-	_, err := db.C(logsCollection).InsertMany(db.Context(), []interface{}{log1, log2, log3, log4})
+	_, err := db.C(logsCollection).InsertMany(env.Context(), []interface{}{log1, log2, log3, log4})
 	assert.NoError(err)
 }
 
@@ -127,10 +128,10 @@ func TestCleanupOldLogsAndTestsByBuild(t *testing.T) {
 	insertTests(t, ids)
 	insertLogs(t, ids)
 
-	count, _ := db.C(testsCollection).CountDocuments(db.Context(), bson.M{})
+	count, _ := db.C(testsCollection).CountDocuments(env.Context(), bson.M{})
 	assert.EqualValues(4, count)
 
-	count, _ = db.C(logsCollection).CountDocuments(db.Context(), bson.M{})
+	count, _ = db.C(logsCollection).CountDocuments(env.Context(), bson.M{})
 	assert.EqualValues(4, count)
 
 	deletedStats, err := CleanupOldLogsAndTestsByBuild(ids[0])
@@ -139,10 +140,10 @@ func TestCleanupOldLogsAndTestsByBuild(t *testing.T) {
 	assert.Equal(1, deletedStats.NumTests)
 	assert.Equal(2, deletedStats.NumLogs)
 
-	count, _ = db.C(testsCollection).CountDocuments(db.Context(), bson.M{})
+	count, _ = db.C(testsCollection).CountDocuments(env.Context(), bson.M{})
 	assert.EqualValues(3, count)
 
-	count, _ = db.C(logsCollection).CountDocuments(db.Context(), bson.M{})
+	count, _ = db.C(logsCollection).CountDocuments(env.Context(), bson.M{})
 	assert.EqualValues(2, count)
 }
 
@@ -161,9 +162,9 @@ func TestNoErrorWithNoLogsOrTests(t *testing.T) {
 		Started: time.Now(),
 	}
 	build := LogKeeperBuild{Id: "incompletebuild"}
-	_, err := db.C(buildsCollection).InsertOne(db.Context(), build)
+	_, err := db.C(buildsCollection).InsertOne(env.Context(), build)
 	assert.NoError(err)
-	_, err = db.C(testsCollection).InsertOne(db.Context(), test)
+	_, err = db.C(testsCollection).InsertOne(env.Context(), test)
 	assert.NoError(err)
 	deletedStats, err := CleanupOldLogsAndTestsByBuild(test.BuildId)
 	assert.NoError(err)
@@ -172,9 +173,9 @@ func TestNoErrorWithNoLogsOrTests(t *testing.T) {
 	assert.Equal(0, deletedStats.NumLogs)
 
 	log := Log{BuildId: "incompletebuild"}
-	_, err = db.C(buildsCollection).InsertOne(db.Context(), build)
+	_, err = db.C(buildsCollection).InsertOne(env.Context(), build)
 	assert.NoError(err)
-	_, err = db.C(logsCollection).InsertOne(db.Context(), log)
+	_, err = db.C(logsCollection).InsertOne(env.Context(), log)
 	assert.NoError(err)
 	deletedStats, err = CleanupOldLogsAndTestsByBuild(log.BuildId)
 	assert.NoError(err)

--- a/views_test.go
+++ b/views_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/logkeeper/db"
+	"github.com/evergreen-ci/logkeeper/env"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
@@ -29,7 +30,7 @@ func TestFindGlobalLogsDuringTest(t *testing.T) {
 		Id:      "b",
 		Started: buildStart,
 	}
-	_, err := db.C("builds").InsertOne(db.Context(), b)
+	_, err := db.C("builds").InsertOne(env.Context(), b)
 	assert.NoError(err)
 
 	t0 := Test{
@@ -37,7 +38,7 @@ func TestFindGlobalLogsDuringTest(t *testing.T) {
 		BuildId: b.Id,
 		Started: buildStart,
 	}
-	_, err = db.C("tests").InsertOne(db.Context(), t0)
+	_, err = db.C("tests").InsertOne(env.Context(), t0)
 	assert.NoError(err)
 
 	t1 := Test{
@@ -45,7 +46,7 @@ func TestFindGlobalLogsDuringTest(t *testing.T) {
 		BuildId: b.Id,
 		Started: buildStart.Add(10 * time.Second),
 	}
-	_, err = db.C("tests").InsertOne(db.Context(), t1)
+	_, err = db.C("tests").InsertOne(env.Context(), t1)
 	assert.NoError(err)
 
 	globalLogTime := t0.Started.Add(5 * time.Second)
@@ -59,7 +60,7 @@ func TestFindGlobalLogsDuringTest(t *testing.T) {
 			*NewLogLine([]interface{}{float64(globalLogTime.Add(10 * time.Second).Unix()), "during t1"}),
 		},
 	}
-	_, err = db.C("logs").InsertOne(db.Context(), globalLog)
+	_, err = db.C("logs").InsertOne(env.Context(), globalLog)
 	assert.NoError(err)
 
 	t0Log := Log{
@@ -72,7 +73,7 @@ func TestFindGlobalLogsDuringTest(t *testing.T) {
 			*NewLogLine([]interface{}{float64(t0.Started.Add(10 * time.Second).Unix()), "t0 - line2"}),
 		},
 	}
-	_, err = db.C("logs").InsertOne(db.Context(), t0Log)
+	_, err = db.C("logs").InsertOne(env.Context(), t0Log)
 	assert.NoError(err)
 
 	t1Log := Log{
@@ -85,7 +86,7 @@ func TestFindGlobalLogsDuringTest(t *testing.T) {
 			*NewLogLine([]interface{}{float64(t1.Started.Add(10 * time.Second).Unix()), "t1 - line2"}),
 		},
 	}
-	_, err = db.C("logs").InsertOne(db.Context(), t1Log)
+	_, err = db.C("logs").InsertOne(env.Context(), t1Log)
 	assert.NoError(err)
 
 	t.Run("BuildStartedAfterTest", func(t *testing.T) {


### PR DESCRIPTION
[EVG-17145](https://jira.mongodb.org/browse/EVG-17145)

The stats cache was [reverted](https://github.com/evergreen-ci/logkeeper/commit/7bc2ce9511e9c3f621ef017b749c5e8500bca50f) because I wanted to make an adjustment to log and reset on the sooner of 1) the ticker fires or 2) the logMBs slice reaches some predetermined size limit. This protects us against killing the application for lack of memory if there's a burst of requests within the log interval.

This PR reapplies the stats cache commit and makes the adjustment (e2cb0a2bf192757e19f97f9a867e9d81af513386).