### PR TITLE
EVG-17145 stats cache take 3

### DIFF
--- a/background.go
+++ b/background.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/evergreen-ci/logkeeper/db"
+	"github.com/evergreen-ci/logkeeper/env"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 )
@@ -26,7 +26,7 @@ func StartBackgroundLogging(ctx context.Context) {
 				if IsLeader() {
 					grip.Info(message.Fields{
 						"message": "amboy queue stats",
-						"stats":   db.GetCleanupQueue().Stats(ctx),
+						"stats":   env.CleanupQueue().Stats(ctx),
 					})
 				}
 

--- a/db/db.go
+++ b/db/db.go
@@ -9,15 +9,9 @@ import (
 
 const defaultSocketTimeout = 90 * time.Second
 
-// Session returns a copy of the global mgo session.
-func Session() *mgo.Session {
-	s := env.Session().Copy()
-	s.SetSocketTimeout(defaultSocketTimeout)
-	return s
-}
-
 // DB returns an mgo Database for the global DBName.
 func DB() (*mgo.Database, func()) {
-	ses := Session()
-	return Session().DB(env.DBName()), ses.Close
+	s := env.Session().Copy()
+	s.SetSocketTimeout(defaultSocketTimeout)
+	return s.DB(env.DBName()), s.Close
 }

--- a/db/db.go
+++ b/db/db.go
@@ -9,13 +9,15 @@ import (
 
 const defaultSocketTimeout = 90 * time.Second
 
+// Session returns a copy of the global mgo session.
 func Session() *mgo.Session {
 	s := env.Session().Copy()
 	s.SetSocketTimeout(defaultSocketTimeout)
 	return s
 }
 
+// DB returns an mgo Database for the global DBName.
 func DB() (*mgo.Database, func()) {
-	ses := env.Session()
-	return ses.DB(env.DBName()), ses.Close
+	ses := Session()
+	return Session().DB(env.DBName()), ses.Close
 }

--- a/db/db.go
+++ b/db/db.go
@@ -1,86 +1,21 @@
 package db
 
 import (
-	"sync"
 	"time"
 
-	"github.com/mongodb/amboy"
-	"github.com/pkg/errors"
+	"github.com/evergreen-ci/logkeeper/env"
 	mgo "gopkg.in/mgo.v2"
 )
 
-type sessionCache struct {
-	s            *mgo.Session
-	cleanupQueue amboy.Queue
-	dbName       string
-
-	sync.RWMutex
-}
-
-var session *sessionCache
-
 const defaultSocketTimeout = 90 * time.Second
 
-func init() {
-	session = &sessionCache{}
-}
-
-func GetSession() *mgo.Session {
-	session.RLock()
-	defer session.RUnlock()
-
-	if session.s == nil {
-		panic("no database connection")
-	}
-
-	s := session.s.Copy()
+func Session() *mgo.Session {
+	s := env.Session().Copy()
 	s.SetSocketTimeout(defaultSocketTimeout)
 	return s
 }
 
-func SetSession(s *mgo.Session) error {
-	session.Lock()
-	defer session.Unlock()
-
-	if s == nil {
-		return errors.New("cannot set a nil session")
-	}
-
-	s.SetSocketTimeout(defaultSocketTimeout)
-	session.s = s
-
-	return nil
-}
-
-func GetDatabase() (*mgo.Database, func()) {
-	session.RLock()
-	defer session.RUnlock()
-
-	ses := GetSession()
-	return ses.DB(session.dbName), ses.Close
-}
-
-func SetDatabase(name string) {
-	session.Lock()
-	defer session.Unlock()
-	session.dbName = name
-}
-
-func SetCleanupQueue(q amboy.Queue) error {
-	if !q.Info().Started {
-		return errors.New("queue isn't started")
-	}
-
-	session.Lock()
-	defer session.Unlock()
-
-	session.cleanupQueue = q
-	return nil
-}
-
-func GetCleanupQueue() amboy.Queue {
-	session.RLock()
-	defer session.RUnlock()
-
-	return session.cleanupQueue
+func DB() (*mgo.Database, func()) {
+	ses := env.Session()
+	return ses.DB(env.DBName()), ses.Close
 }

--- a/db/db.go
+++ b/db/db.go
@@ -9,7 +9,7 @@ import (
 
 const defaultSocketTimeout = 90 * time.Second
 
-// DB returns an mgo Database for the global DBName.
+// DB returns an mgo Database for the global DBName and the mgo session closer func.
 func DB() (*mgo.Database, func()) {
 	s := env.Session().Copy()
 	s.SetSocketTimeout(defaultSocketTimeout)

--- a/env/environment.go
+++ b/env/environment.go
@@ -1,0 +1,74 @@
+package env
+
+import (
+	"sync"
+
+	"github.com/mongodb/amboy"
+	"github.com/pkg/errors"
+	mgo "gopkg.in/mgo.v2"
+)
+
+type environment struct {
+	dbSession    *mgo.Session
+	cleanupQueue amboy.Queue
+	dbName       string
+
+	sync.RWMutex
+}
+
+var globalEnv *environment
+
+func init() {
+	globalEnv = &environment{}
+}
+
+func SetSession(s *mgo.Session) error {
+	if s == nil {
+		return errors.New("cannot set a nil session")
+	}
+
+	globalEnv.Lock()
+	defer globalEnv.Unlock()
+	globalEnv.dbSession = s
+
+	return nil
+}
+
+func Session() *mgo.Session {
+	globalEnv.RLock()
+	defer globalEnv.RUnlock()
+
+	return globalEnv.dbSession
+}
+
+func SetDBName(name string) {
+	globalEnv.Lock()
+	defer globalEnv.Unlock()
+
+	globalEnv.dbName = name
+}
+
+func DBName() string {
+	globalEnv.RLock()
+	defer globalEnv.RUnlock()
+
+	return globalEnv.dbName
+}
+
+func SetCleanupQueue(q amboy.Queue) error {
+	if !q.Info().Started {
+		return errors.New("queue isn't started")
+	}
+
+	globalEnv.Lock()
+	defer globalEnv.Unlock()
+	globalEnv.cleanupQueue = q
+	return nil
+}
+
+func CleanupQueue() amboy.Queue {
+	globalEnv.RLock()
+	defer globalEnv.RUnlock()
+
+	return globalEnv.cleanupQueue
+}

--- a/env/environment.go
+++ b/env/environment.go
@@ -10,8 +10,9 @@ import (
 
 type environment struct {
 	dbSession    *mgo.Session
-	cleanupQueue amboy.Queue
 	dbName       string
+	cleanupQueue amboy.Queue
+	stats        *statsCache
 
 	sync.RWMutex
 }
@@ -22,6 +23,7 @@ func init() {
 	globalEnv = &environment{}
 }
 
+// SetSession caches a mgo session to be available from the environment.
 func SetSession(s *mgo.Session) error {
 	if s == nil {
 		return errors.New("cannot set a nil session")
@@ -34,6 +36,7 @@ func SetSession(s *mgo.Session) error {
 	return nil
 }
 
+// Session returns the cached mgo session from the environment.
 func Session() *mgo.Session {
 	globalEnv.RLock()
 	defer globalEnv.RUnlock()
@@ -41,6 +44,7 @@ func Session() *mgo.Session {
 	return globalEnv.dbSession
 }
 
+// SetDBName caches a DB name to be available from the environment.
 func SetDBName(name string) {
 	globalEnv.Lock()
 	defer globalEnv.Unlock()
@@ -48,6 +52,7 @@ func SetDBName(name string) {
 	globalEnv.dbName = name
 }
 
+// DBName returns the cached DB name from the environment.
 func DBName() string {
 	globalEnv.RLock()
 	defer globalEnv.RUnlock()
@@ -55,6 +60,23 @@ func DBName() string {
 	return globalEnv.dbName
 }
 
+// SetStatsCache caches a stats cache to be available from the environment.
+func SetStatsCache(s *statsCache) {
+	globalEnv.Lock()
+	defer globalEnv.Unlock()
+
+	globalEnv.stats = s
+}
+
+// StatsCache returns the cached stats cache from the environment.
+func StatsCache() *statsCache {
+	globalEnv.RLock()
+	defer globalEnv.RUnlock()
+
+	return globalEnv.stats
+}
+
+// SetCleanupQueue caches the cleanup queue to be available from the environment.
 func SetCleanupQueue(q amboy.Queue) error {
 	if !q.Info().Started {
 		return errors.New("queue isn't started")
@@ -66,6 +88,7 @@ func SetCleanupQueue(q amboy.Queue) error {
 	return nil
 }
 
+// CleanupQueue returns the cached cleanup queue from the environment.
 func CleanupQueue() amboy.Queue {
 	globalEnv.RLock()
 	defer globalEnv.RUnlock()

--- a/env/stats_cache.go
+++ b/env/stats_cache.go
@@ -19,7 +19,7 @@ const (
 	bytesPerMB         = 1000000
 )
 
-var histogramDividers = []float64{0, 0.5, 1, 5, 10, 40}
+var histogramDividers = []float64{0, 0.5, 1, 5, 10, 50}
 
 type statsCache struct {
 	buildsCreated int

--- a/env/stats_cache.go
+++ b/env/stats_cache.go
@@ -1,0 +1,156 @@
+package env
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/recovery"
+	"gonum.org/v1/gonum/floats"
+	"gonum.org/v1/gonum/stat"
+)
+
+const (
+	statChanBufferSize = 1000
+	sizesLimit         = 100000
+	logInterval        = 10 * time.Second
+	bytesPerMB         = 1000000
+)
+
+var histogramDividers = []float64{0, 0.5, 1, 5, 10, 40}
+
+type statsCache struct {
+	buildsCreated int
+	testsCreated  int
+	logMBs        []float64
+
+	buildsAccessed       int
+	allBuildLogsAccessed int
+	testLogsAccessed     int
+
+	changeChan chan func(*statsCache)
+	lastReset  time.Time
+}
+
+// BuildCreated records that a build has been created.
+// Returns an error if events are enqueued faster than the cache can process them.
+func (s *statsCache) BuildCreated() error {
+	return s.enqueueChange(func(s *statsCache) { s.buildsCreated++ })
+}
+
+// TestCreated records that a test has been created.
+// Returns an error if events are enqueued faster than the cache can process them.
+func (s *statsCache) TestCreated() error {
+	return s.enqueueChange(func(s *statsCache) { s.testsCreated++ })
+}
+
+// LogAppended records that a log has been appended.
+// Returns an error if events are enqueued faster than the cache can process them.
+func (s *statsCache) LogAppended(numBytes int) error {
+	return s.enqueueChange(func(s *statsCache) { s.logMBs = append(s.logMBs, float64(numBytes)/bytesPerMB) })
+}
+
+// BuildAccessed records that a build has been accessed.
+// Returns an error if events are enqueued faster than the cache can process them.
+func (s *statsCache) BuildAccessed() error {
+	return s.enqueueChange(func(s *statsCache) { s.buildsAccessed++ })
+}
+
+// TestLogsAccessed records that a test's logs have been accessed.
+// Returns an error if events are enqueued faster than the cache can process them.
+func (s *statsCache) TestLogsAccessed() error {
+	return s.enqueueChange(func(s *statsCache) { s.testLogsAccessed++ })
+}
+
+// AllLogsAccessed records that all of a build's logs have been accessed.
+// Returns an error if events are enqueued faster than the cache can process them.
+func (s *statsCache) AllLogsAccessed() error {
+	return s.enqueueChange(func(s *statsCache) { s.allBuildLogsAccessed++ })
+}
+
+func (s *statsCache) enqueueChange(change func(*statsCache)) error {
+	select {
+	case s.changeChan <- change:
+		return nil
+	default:
+		return errors.New("incoming stats buffer is full")
+	}
+}
+
+func (s *statsCache) logStats() {
+	stats := message.Fields{
+		"message":                     "usage stats",
+		"interval_ms":                 time.Since(s.lastReset).Milliseconds(),
+		"num_builds_created":          s.buildsCreated,
+		"num_tests_created":           s.testsCreated,
+		"num_appends":                 len(s.logMBs),
+		"num_builds_accessed":         s.buildsAccessed,
+		"num_all_build_logs_accessed": s.allBuildLogsAccessed,
+		"num_test_logs_accessed":      s.testLogsAccessed,
+	}
+	if len(s.logMBs) > 0 {
+		stats["append_size_total"] = floats.Sum(s.logMBs)
+		stats["append_size_min"] = floats.Min(s.logMBs)
+		stats["append_size_max"] = floats.Max(s.logMBs)
+		stats["append_size_mean"] = stat.Mean(s.logMBs, nil)
+		stats["append_size_stddev"] = stat.StdDev(s.logMBs, nil)
+		stats["histogram"] = stat.Histogram(nil, histogramDividers, s.logMBs, nil)
+	}
+	grip.Info(stats)
+}
+
+func (s *statsCache) resetCache() {
+	s.buildsCreated = 0
+	s.testsCreated = 0
+	s.logMBs = s.logMBs[:0]
+
+	s.buildsAccessed = 0
+	s.allBuildLogsAccessed = 0
+	s.testLogsAccessed = 0
+
+	s.lastReset = time.Now()
+}
+
+func (s *statsCache) loggerLoop(ctx context.Context) {
+	defer func() {
+		if err := recovery.HandlePanicWithError(recover(), nil, "stats cache logger"); err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": "panic in stats cache logger loop",
+			}))
+		}
+	}()
+
+	ticker := time.NewTicker(logInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.logStats()
+			s.resetCache()
+		case applyChange := <-s.changeChan:
+			applyChange(s)
+
+			if len(s.logMBs) >= sizesLimit {
+				s.logStats()
+				s.resetCache()
+				ticker.Reset(logInterval)
+			}
+		}
+	}
+}
+
+// NewStatsCache returns an initialized stats cache and begins processing incoming events.
+func NewStatsCache(ctx context.Context) *statsCache {
+	cache := statsCache{
+		lastReset:  time.Now(),
+		changeChan: make(chan func(*statsCache), statChanBufferSize),
+	}
+	go cache.loggerLoop(ctx)
+
+	return &cache
+}

--- a/env/stats_cache_test.go
+++ b/env/stats_cache_test.go
@@ -1,0 +1,102 @@
+package env
+
+import (
+	"testing"
+
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/send"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func TestLoggerLoop(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*logInterval)
+	defer cancel()
+	defer grip.SetSender(grip.GetSender())
+
+	cache := NewStatsCache(ctx)
+	for testName, testCase := range map[string]struct {
+		mutator func() error
+		field   string
+	}{
+		"BuildCreated":    {mutator: cache.BuildCreated, field: "num_builds_created"},
+		"TestCreated":     {mutator: cache.TestCreated, field: "num_tests_created"},
+		"Append":          {mutator: func() error { return cache.LogAppended(5) }, field: "num_appends"},
+		"BuildsAccessed":  {mutator: cache.BuildAccessed, field: "num_builds_accessed"},
+		"TestLogAccessed": {mutator: cache.TestLogsAccessed, field: "num_test_logs_accessed"},
+		"AllLogsAccessed": {mutator: cache.AllLogsAccessed, field: "num_all_build_logs_accessed"},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			sender := send.NewMockSender("")
+			grip.SetSender(sender)
+
+			assert.NoError(t, testCase.mutator())
+
+			require.Eventually(t, func() bool { return len(sender.Messages) > 0 }, 2*logInterval, logInterval/2)
+			msg := sender.Messages[0].Raw().(message.Fields)
+			for _, field := range []string{
+				"num_builds_created",
+				"num_tests_created",
+				"num_appends",
+				"num_builds_accessed",
+				"num_all_build_logs_accessed",
+				"num_test_logs_accessed",
+			} {
+				if field == testCase.field {
+					assert.Equal(t, 1, msg[field])
+				} else {
+					assert.Equal(t, 0, msg[field])
+				}
+			}
+		})
+	}
+}
+
+func TestChannelFull(t *testing.T) {
+	defer grip.SetSender(grip.GetSender())
+	sender := send.NewMockSender("")
+	grip.SetSender(sender)
+
+	cache := statsCache{changeChan: make(chan func(*statsCache), 5)}
+	for x := 0; x < 5; x++ {
+		cache.BuildCreated()
+	}
+	assert.Len(t, sender.Messages, 0)
+
+	assert.Error(t, cache.BuildCreated())
+}
+
+func TestLogSizeStats(t *testing.T) {
+	defer grip.SetSender(grip.GetSender())
+
+	t.Run("WithValues", func(t *testing.T) {
+		sender := send.NewMockSender("")
+		grip.SetSender(sender)
+
+		cache := statsCache{
+			logMBs: []float64{0, 15, 30},
+		}
+		cache.logStats()
+
+		require.Len(t, sender.Messages, 1)
+		msg := sender.Messages[0].Raw().(message.Fields)
+		assert.EqualValues(t, 45, msg["append_size_total"])
+		assert.EqualValues(t, 0, msg["append_size_min"])
+		assert.EqualValues(t, 30, msg["append_size_max"])
+		assert.EqualValues(t, 15, msg["append_size_mean"])
+		assert.EqualValues(t, 15, msg["append_size_stddev"])
+		assert.Equal(t, []float64{1, 0, 0, 0, 2}, msg["histogram"])
+	})
+	t.Run("WithoutValues", func(t *testing.T) {
+		sender := send.NewMockSender("")
+		grip.SetSender(sender)
+
+		cache := statsCache{}
+		cache.logStats()
+		require.Len(t, sender.Messages, 1)
+		_, ok := sender.Messages[0].Raw().(message.Fields)["append_size_min"]
+		assert.False(t, ok)
+	})
+}

--- a/env/stats_cache_test.go
+++ b/env/stats_cache_test.go
@@ -78,7 +78,7 @@ func TestLogSizeStats(t *testing.T) {
 		cache := statsCache{
 			logMBs: []float64{0, 15, 30},
 		}
-		cache.logStats()
+		cache.flushStats()
 
 		require.Len(t, sender.Messages, 1)
 		msg := sender.Messages[0].Raw().(message.Fields)
@@ -94,7 +94,7 @@ func TestLogSizeStats(t *testing.T) {
 		grip.SetSender(sender)
 
 		cache := statsCache{}
-		cache.logStats()
+		cache.flushStats()
 		require.Len(t, sender.Messages, 1)
 		_, ok := sender.Messages[0].Raw().(message.Fields)["append_size_min"]
 		assert.False(t, ok)

--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,7 @@ require (
 	github.com/smartystreets/goconvey v1.5.1-0.20140605153011-75bc4a2dad71
 	github.com/stretchr/testify v1.8.0
 	github.com/urfave/negroni v1.0.0
+	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
+	gonum.org/v1/gonum v0.11.0
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
 )

--- a/logkeeper_test.go
+++ b/logkeeper_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/logkeeper/db"
+	"github.com/evergreen-ci/logkeeper/env"
 	"github.com/mongodb/grip"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/smartystreets/goconvey/convey/reporting"
@@ -32,13 +33,15 @@ func TestLogKeeper(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = db.SetSession(session); err != nil {
+	env.SetDBName("logkeeper_test")
+	if err = env.SetSession(session); err != nil {
 		t.Fatal(err)
 	}
+	db, closer := db.DB()
+	defer closer()
 
 	Convey("LogKeeper instance running on testdatabase", t, func() {
-		lk := New(Options{DB: "logkeeper_test", MaxRequestSize: 1024 * 1024 * 10})
-		db := session.DB("logkeeper_test")
+		lk := New(Options{MaxRequestSize: 1024 * 1024 * 10})
 		router := lk.NewRouter()
 
 		Convey("Call POST /build creates a build with the given builder/buildnum", func() {

--- a/main/logkeeper.go
+++ b/main/logkeeper.go
@@ -67,6 +67,7 @@ func main() {
 	grip.EmergencyFatal(cleanupQueue.SetRunner(runner))
 	grip.EmergencyFatal(cleanupQueue.Start(ctx))
 	grip.EmergencyFatal(env.SetCleanupQueue(cleanupQueue))
+	env.SetStatsCache(env.NewStatsCache(ctx))
 
 	grip.EmergencyFatal(units.StartCrons(ctx, cleanupQueue))
 

--- a/schema.go
+++ b/schema.go
@@ -124,7 +124,7 @@ func UpdateFailedBuild(id interface{}) error {
 		return errors.New("no build id defined")
 	}
 
-	db, closer := db.GetDatabase()
+	db, closer := db.DB()
 	defer closer()
 
 	err := db.C(buildsName).UpdateId(id, bson.M{"$set": bson.M{"failed": true}})
@@ -133,7 +133,7 @@ func UpdateFailedBuild(id interface{}) error {
 }
 
 func GetOldBuilds(limit int) ([]LogKeeperBuild, error) {
-	db, closer := db.GetDatabase()
+	db, closer := db.DB()
 	defer closer()
 	query := getOldBuildQuery()
 
@@ -163,7 +163,7 @@ func getOldBuildQuery() bson.M {
 }
 
 func StreamingGetOldBuilds(ctx context.Context) (<-chan LogKeeperBuild, <-chan error) {
-	db, closer := db.GetDatabase()
+	db, closer := db.DB()
 
 	errOut := make(chan error)
 	out := make(chan LogKeeperBuild)
@@ -199,7 +199,7 @@ func CleanupOldLogsAndTestsByBuild(id interface{}) (int, error) {
 		return 0, errors.New("no build ID defined")
 	}
 
-	db, closer := db.GetDatabase()
+	db, closer := db.DB()
 	defer closer()
 
 	var err error

--- a/schema_test.go
+++ b/schema_test.go
@@ -12,7 +12,7 @@ import (
 
 func insertBuilds(t *testing.T) []interface{} {
 	assert := assert.New(t)
-	db, closer := db.GetDatabase()
+	db, closer := db.DB()
 	defer closer()
 	_, err := db.C(buildsName).RemoveAll(bson.M{})
 	require.NoError(t, err)
@@ -47,7 +47,7 @@ func insertBuilds(t *testing.T) []interface{} {
 
 func insertTests(t *testing.T, ids []interface{}) {
 	assert := assert.New(t)
-	db, closer := db.GetDatabase()
+	db, closer := db.DB()
 	defer closer()
 	_, err := db.C(testsName).RemoveAll(bson.M{})
 	require.NoError(t, err)
@@ -73,7 +73,7 @@ func insertTests(t *testing.T, ids []interface{}) {
 
 func insertLogs(t *testing.T, ids []interface{}) {
 	assert := assert.New(t)
-	db, closer := db.GetDatabase()
+	db, closer := db.DB()
 	defer closer()
 	_, err := db.C(logsName).RemoveAll(bson.M{})
 	require.NoError(t, err)
@@ -99,7 +99,7 @@ func TestGetOldTests(t *testing.T) {
 
 func TestCleanupOldLogsAndTestsByBuild(t *testing.T) {
 	assert := assert.New(t)
-	db, closer := db.GetDatabase()
+	db, closer := db.DB()
 	defer closer()
 
 	ids := insertBuilds(t)
@@ -125,7 +125,7 @@ func TestCleanupOldLogsAndTestsByBuild(t *testing.T) {
 
 func TestNoErrorWithNoLogsOrTests(t *testing.T) {
 	assert := assert.New(t)
-	db, closer := db.GetDatabase()
+	db, closer := db.DB()
 	defer closer()
 	_, err := db.C(testsName).RemoveAll(bson.M{})
 	require.NoError(t, err)


### PR DESCRIPTION
[EVG-17145](https://jira.mongodb.org/browse/EVG-17145)

This is intended to be mostly the same as #66 except that it's not based on the now reverted mgo -> mongo commit (#62). Because we believe the revert is likely permanent this had to be done over from scratch.