### PR TITLE
EVG-17147 defer recovery

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/recovery"
 	"github.com/mongodb/grip/sometimes"
 	"github.com/pkg/errors"
 	"github.com/urfave/negroni"
@@ -122,6 +123,8 @@ func (l *Logger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 }
 
 func (l *Logger) responseLoggerLoop(ctx context.Context) {
+	defer recovery.LogStackTraceAndContinue("logger loop")
+
 	ticker := time.NewTicker(loggerStatsInterval)
 	defer ticker.Stop()
 


### PR DESCRIPTION
[EVG-17147](https://jira.mongodb.org/browse/EVG-17147)

In #69 I neglected to recover a panic in the logger loop.
In the unlikely event it does panic we'll stop logging, but that seems better than killing the application entirely. [The alert](https://github.com/mongodb/grip/blob/ae59645b416e7b68c8789ef3b5d43a93f6b732f1/recovery/recovery.go#L187) should bring it to our attention so we can restart the application manually.