### PR TITLE
EVG-17147 fix race in test

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -69,7 +69,7 @@ func NewLogger(ctx context.Context) *Logger {
 	}
 
 	go l.incrementIDLoop(ctx)
-	go l.responseLoggerLoop(ctx)
+	go l.responseLoggerLoop(ctx, loggerStatsInterval)
 
 	return l
 }
@@ -122,10 +122,10 @@ func (l *Logger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 	)
 }
 
-func (l *Logger) responseLoggerLoop(ctx context.Context) {
+func (l *Logger) responseLoggerLoop(ctx context.Context, tickerInterval time.Duration) {
 	defer recovery.LogStackTraceAndContinue("logger loop")
 
-	ticker := time.NewTicker(loggerStatsInterval)
+	ticker := time.NewTicker(tickerInterval)
 	defer ticker.Stop()
 
 	for {
@@ -139,7 +139,7 @@ func (l *Logger) responseLoggerLoop(ctx context.Context) {
 
 			if l.cacheIsFull {
 				l.flushStats()
-				ticker.Reset(loggerStatsInterval)
+				ticker.Reset(tickerInterval)
 			}
 		}
 	}


### PR DESCRIPTION
[EVG-17147](https://jira.mongodb.org/browse/EVG-17147)

I forgot about the race detector when I wrote the tests. They were not coordinating around accesses to the mock sender's message slice because the test would spin on checking the slice while the logger loop wrote to it from another goroutine. 

I rewrote the tests that were racing so the loop and test are all the same goroutine. The tests were taking a while so I made the ticker interval configurable in order to speed up the tests.