### PR TITLE
EVG-17147 sort slice

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -239,7 +239,7 @@ func sliceStats(sample, histogramBins []float64) message.Fields {
 	if len(sample) == 0 {
 		return message.Fields{}
 	}
-	sort.Float64Slice(sample).Sort()
+	sort.Float64s(sample)
 
 	min := sample[0]
 	max := sample[len(sample)-1]

--- a/logger.go
+++ b/logger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -238,9 +239,10 @@ func sliceStats(sample, histogramBins []float64) message.Fields {
 	if len(sample) == 0 {
 		return message.Fields{}
 	}
+	sort.Float64Slice(sample).Sort()
 
-	min := floats.Min(sample)
-	max := floats.Max(sample)
+	min := sample[0]
+	max := sample[len(sample)-1]
 	if len(histogramBins) == 0 || histogramBins[0] > min || histogramBins[len(histogramBins)-1] <= max {
 		return message.Fields{}
 	}

--- a/logger_test.go
+++ b/logger_test.go
@@ -167,6 +167,18 @@ func TestSliceStats(t *testing.T) {
 		bins := []float64{0, 1, 5, 10}
 		assert.Equal(t, message.Fields{}, sliceStats(sample, bins))
 	})
+
+	t.Run("OutOfOrder", func(t *testing.T) {
+		sample := []float64{10, 5, 0}
+		bins := []float64{0, 1, 5, 10, 20}
+		stats := sliceStats(sample, bins)
+		assert.EqualValues(t, stats["sum"], 15)
+		assert.EqualValues(t, stats["min"], 0)
+		assert.EqualValues(t, stats["max"], 10)
+		assert.EqualValues(t, stats["mean"], 5)
+		assert.EqualValues(t, stats["std_dev"], 5)
+		assert.EqualValues(t, stats["histogram"], []float64{1, 0, 1, 1})
+	})
 }
 
 func TestMakeMessage(t *testing.T) {


### PR DESCRIPTION
[EVG-17147](https://jira.mongodb.org/browse/EVG-17147)

The panics from the previous deploy were due to failing [this check](https://github.com/gonum/gonum/blob/1180659542815ddb51545f83860386272ebf0d9b/stat/stat.go#L504-L506). Looking over the entire list of checks there it looks like we're safe now.