### PR TITLE
EVG-17451 differentiate HTTP methods

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -2,9 +2,11 @@ package logkeeper
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -170,6 +172,10 @@ func (l *Logger) addToResponseBuffer(rw http.ResponseWriter, r *http.Request) er
 	if err != nil {
 		return errors.Wrap(err, "getting path template")
 	}
+	methods, err := route.GetMethods()
+	if err != nil {
+		return errors.Wrap(err, "getting methods")
+	}
 
 	writer, ok := rw.(negroni.ResponseWriter)
 	if !ok {
@@ -178,7 +184,7 @@ func (l *Logger) addToResponseBuffer(rw http.ResponseWriter, r *http.Request) er
 
 	select {
 	case l.newResponses <- routeResponse{
-		route:        path,
+		route:        fmt.Sprintf("[%s] %s", strings.Join(methods, ", "), path),
 		duration:     time.Since(getRequestStartAt(r.Context())),
 		status:       writer.Status(),
 		responseSize: writer.Size(),


### PR DESCRIPTION
[EVG-17451](https://jira.mongodb.org/browse/EVG-17451)

Separate the routes based on the HTTP method. 

### Testing
I tried it out with the smoke test. I got two separate messages in `logkeeperapp.log` for the `/build/{build_id}/test/{test_id}` route
```
route='[GET] /build/{build_id}/test/{test_id}'
```
and 
```
route='[POST] /build/{build_id}/test/{test_id}'
```