### PR TITLE
EVG-17451 skip empty messages

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -217,6 +217,10 @@ func (l *Logger) recordResponse(response routeResponse) {
 
 func (l *Logger) flushStats() {
 	for route, stats := range l.statsByRoute {
+		if stats.count() == 0 {
+			continue
+		}
+
 		msg := stats.makeMessage()
 		msg["route"] = route
 		msg["interval"] = time.Since(l.lastReset)
@@ -227,10 +231,14 @@ func (l *Logger) flushStats() {
 	l.resetStats()
 }
 
+func (s *routeStats) count() int {
+	return len(s.durationMS)
+}
+
 func (s *routeStats) makeMessage() message.Fields {
 	msg := message.Fields{
 		"message":  "route stats",
-		"count":    len(s.durationMS),
+		"count":    s.count(),
 		"statuses": s.statusCounts,
 	}
 


### PR DESCRIPTION
[EVG-17451](https://jira.mongodb.org/browse/EVG-17451)

One more improvement to logging: it's not helpful to log messages for routes that haven't seen any requests. For one thing, it's unnecessarily consuming our Splunk allowance. Also, it's an extra step to filter them out when we're trying to find averages.