### PR TITLE
EVG-17461 log to file

### DIFF
--- a/main/logkeeper.go
+++ b/main/logkeeper.go
@@ -35,7 +35,7 @@ func main() {
 	dbHost := flag.String("dbhost", "localhost:27017", "host/port to connect to DB server. Comma separated.")
 	rsName := flag.String("rsName", "", "name of replica set that the DB instances belong to. "+
 		"Leave empty for stand-alone and mongos instances.")
-	localPath := flag.String("localPath", "", "local path to save data to. Omit to save data to S3.")
+	localPath := flag.String("localPath", "_bucketdata", "local path to save data to")
 	logPath := flag.String("logpath", "logkeeperapp.log", "path to log file")
 	maxRequestSize := flag.Int("maxRequestSize", 1024*1024*32,
 		"maximum size for a request in bytes, defaults to 32 MB (in bytes)")

--- a/makefile
+++ b/makefile
@@ -4,7 +4,6 @@ buildDir := build
 packages := $(name) storage model
 orgPath := github.com/evergreen-ci
 projectPath := $(orgPath)/$(name)
-tempStorageDir := _bucketdata
 
 # end project configuration
 
@@ -123,8 +122,7 @@ $(buildDir)/output.%.coverage: .FORCE
 $(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
 	go tool cover -html=$< -o $@
 $(buildDir)/output.smoke.test: $(buildDir)/$(name)
-	mkdir -p $(tempStorageDir)
-	./$< --localPath $(tempStorageDir) &
+	./$< &
 	PORT=8080 go test $(testArgs) -v ./smoke/smoke_test.go | tee $(buildDir)/output.smoke.test || (pkill -f $<; exit 1)
 	pkill -f $<
 # end test and coverage artifacts

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -12,6 +12,8 @@ const (
 	awsSecretEnvVariable = "AWS_SECRET"
 	awsBucketEnvVariable = "AWS_S3_BUCKET"
 	defaultS3Region      = "us-east-1"
+
+	localBucketPermissions = 0750
 )
 
 type Bucket struct {
@@ -41,6 +43,13 @@ func NewBucket(opts BucketOpts) (Bucket, error) {
 func (opts *BucketOpts) getBucket() (pail.Bucket, error) {
 	switch opts.Location {
 	case PailLocal:
+		if opts.Path == "" {
+			return nil, errors.New("local path must be specified")
+		}
+		if err := os.MkdirAll(opts.Path, localBucketPermissions); err != nil {
+			return nil, errors.Wrapf(err, "creating local path '%s'", opts.Path)
+		}
+
 		localBucket, err := pail.NewLocalBucket(pail.LocalOptions{
 			Path: opts.Path,
 		})


### PR DESCRIPTION
[EVG-17461](https://jira.mongodb.org/browse/EVG-17461)

This will make logkeeper start so we can continue to deploy until we get the expected environment variables in place ([EVG-17460](https://jira.mongodb.org/browse/EVG-17460)).