### PR TITLE
EVG-17463 use the correct unit

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -26,7 +26,7 @@ const (
 	loggerStatsInterval  = 10 * time.Second
 	statsLimit           = 100000
 	logErrorPercentage   = 10
-	bytesPerMB           = 1000000
+	bytesPerMB           = 1024 * 1024
 )
 
 var (


### PR DESCRIPTION
[EVG-17463](https://jira.mongodb.org/browse/EVG-17463)

Use 1024^2 for `bytesPerMB` instead of 1000000.