### PR TITLE
EVG-17150 upload test metadata

### DIFF
--- a/model/build.go
+++ b/model/build.go
@@ -29,6 +29,7 @@ type Build struct {
 	Failed   bool      `bson:"failed"`
 	Phases   []string  `bson:"phases"`
 	Seq      int       `bson:"seq"`
+	S3       bool      `bson:"s3,omitempty"`
 }
 
 // BuildInfo contains additional metadata about a build.

--- a/storage/persistence.go
+++ b/storage/persistence.go
@@ -12,8 +12,18 @@ func (b *Bucket) UploadBuildMetadata(ctx context.Context, build model.Build) err
 	metadata := newBuildMetadata(build)
 	json, err := metadata.toJSON()
 	if err != nil {
-		return errors.Wrap(err, "getting metadata JSON")
+		return errors.Wrap(err, "getting metadata JSON for build")
 	}
 
-	return errors.Wrapf(b.Put(ctx, metadata.key(), bytes.NewReader(json)), "putting build metadata for build '%s'", build.Id)
+	return errors.Wrapf(b.Put(ctx, metadata.key(), bytes.NewReader(json)), "putting metadata for build '%s'", build.Id)
+}
+
+func (b *Bucket) UploadTestMetadata(ctx context.Context, test model.Test) error {
+	metadata := newTestMetadata(test)
+	json, err := metadata.toJSON()
+	if err != nil {
+		return errors.Wrap(err, "getting metadata JSON for test")
+	}
+
+	return errors.Wrapf(b.Put(ctx, metadata.key(), bytes.NewReader(json)), "putting metadata for test '%s'", test.Id)
 }

--- a/storage/persistence_test.go
+++ b/storage/persistence_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/evergreen-ci/logkeeper/model"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/mgo.v2/bson"
 )
 
 func TestUploadBuildMetadata(t *testing.T) {
@@ -27,5 +28,26 @@ func TestUploadBuildMetadata(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedMetadata := `{"id":"5a75f537726934e4b62833ab6d5dca41","builder":"builder0","buildnum":1,"task_id":"t0"}`
-	assert.Equal(t, expectedMetadata, string(contents))
+	assert.JSONEq(t, expectedMetadata, string(contents))
+}
+
+func TestUploadTestMetadata(t *testing.T) {
+	storage := makeTestStorage(t, "")
+	defer cleanTestStorage(t)
+
+	test := model.Test{
+		Id:      bson.ObjectIdHex("62dba0159041307f697e6ccc"),
+		BuildId: "5a75f537726934e4b62833ab6d5dca41",
+		Name:    "test0",
+		Info:    model.TestInfo{TaskID: "t0"},
+	}
+
+	assert.NoError(t, storage.UploadTestMetadata(context.Background(), test))
+	results, err := storage.Get(context.Background(), "/builds/5a75f537726934e4b62833ab6d5dca41/tests/62dba0159041307f697e6ccc/metadata.json")
+	assert.NoError(t, err)
+	contents, err := io.ReadAll(results)
+	assert.NoError(t, err)
+
+	expectedMetadata := `{"id":"62dba0159041307f697e6ccc","name":"test0","build_id":"5a75f537726934e4b62833ab6d5dca41","task_id":"t0"}`
+	assert.JSONEq(t, expectedMetadata, string(contents))
 }

--- a/storage/storage_model.go
+++ b/storage/storage_model.go
@@ -73,7 +73,7 @@ func buildPrefix(buildID string) string {
 }
 
 func testPrefix(buildID, testID string) string {
-	return fmt.Sprintf("/builds/%s/tests/%s/", buildID, testID)
+	return fmt.Sprintf("%stests/%s/", buildPrefix(buildID), testID)
 }
 
 type buildMetadata struct {
@@ -125,6 +125,15 @@ type testMetadata struct {
 	Name    string `json:"name"`
 	BuildID string `json:"build_id"`
 	TaskID  string `json:"task_id"`
+}
+
+func newTestMetadata(t model.Test) testMetadata {
+	return testMetadata{
+		ID:      t.Id.Hex(),
+		BuildID: t.BuildId,
+		Name:    t.Name,
+		TaskID:  t.Info.TaskID,
+	}
 }
 
 func (m *testMetadata) toTest() model.Test {


### PR DESCRIPTION
[EVG-17150](https://jira.mongodb.org/browse/EVG-17150)

Write test metadata to S3. Mostly the same as creating a build.

I added a field to the build document in the db that will indicate if we're duplicating to S3. If we are then all subsequent operations go to S3 too. This strategy is just for testing. In the goal state we'll stop doing this and just write everything to S3 (instead of the db).