### PR TITLE
EVG-17154: Add ability to retrieve build from S3

### DIFF
--- a/storage/retrieval.go
+++ b/storage/retrieval.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/logkeeper/model"
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 )
 

--- a/storage/retrieval.go
+++ b/storage/retrieval.go
@@ -182,13 +182,13 @@ func (b *Bucket) FindTestsForBuild(ctx context.Context, buildId string) ([]model
 	iterator, listErr := b.List(ctx, buildTestsPrefix(buildId))
 	testIds := []string{}
 	if listErr != nil {
-		return nil, errors.Wrapf(listErr, "listing test keys for build %s", buildId)
+		return nil, errors.Wrapf(listErr, "listing test keys for build '%s'	", buildId)
 	}
 	for iterator.Next(ctx) {
 		if strings.HasSuffix(iterator.Item().Name(), metadataFilename) {
 			testId, parseError := testIdFromKey(iterator.Item().Name())
 			if parseError != nil {
-				return nil, errors.Wrapf(parseError, "parsing test metadata key for build %s", buildId)
+				return nil, errors.Wrapf(parseError, "parsing test metadata key for build '%s'", buildId)
 			}
 			testIds = append(testIds, testId)
 		}
@@ -208,7 +208,7 @@ func (b *Bucket) FindTestsForBuild(ctx context.Context, buildId string) ([]model
 			defer wg.Done()
 			test, err := b.FindTestByID(ctx, buildId, closureTestId)
 			if err != nil {
-				catcher.Wrapf(err, "fetching test ID %s under build ID '%s'", closureTestId, buildId)
+				catcher.Wrapf(err, "fetching test ID '%s' under build ID '%s'", closureTestId, buildId)
 			} else {
 				testResults[closureIndex] = *test
 			}

--- a/storage/retrieval.go
+++ b/storage/retrieval.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/evergreen-ci/logkeeper/model"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/recovery"
 	"github.com/pkg/errors"
 )
 
@@ -203,6 +204,7 @@ func (b *Bucket) FindTestsForBuild(ctx context.Context, buildId string) ([]model
 		closureTestId := testId
 		closureIndex := index
 		go func() {
+			defer recovery.LogStackTraceAndContinue("fetching tests from s3 for build")
 			defer wg.Done()
 			test, err := b.FindTestByID(ctx, buildId, closureTestId)
 			if err != nil {

--- a/storage/retrieval_test.go
+++ b/storage/retrieval_test.go
@@ -196,3 +196,30 @@ func TestFindTestById(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, &expected, testResponse)
 }
+
+func TestFindTestsForBuild(t *testing.T) {
+	storage := makeTestStorage(t, "../testdata/between")
+	defer cleanTestStorage(t)
+
+	expected := []model.Test{
+		{
+			Id:      bson.ObjectIdHex("62dba0159041307f697e6ccc"),
+			BuildId: "5a75f537726934e4b62833ab6d5dca41",
+			Name:    "geo_max:CheckReplOplogs",
+			Info: model.TestInfo{
+				TaskID: "Task",
+			},
+		},
+		{
+			Id:      bson.ObjectIdHex("72dba0159041307f697e6ccd"),
+			BuildId: "5a75f537726934e4b62833ab6d5dca41",
+			Name:    "geo_max:CheckReplOplogs2",
+			Info: model.TestInfo{
+				TaskID: "Task",
+			},
+		},
+	}
+	testResponse, err := storage.FindTestsForBuild(context.Background(), "5a75f537726934e4b62833ab6d5dca41")
+	require.NoError(t, err)
+	assert.Equal(t, expected, testResponse)
+}

--- a/storage/storage_model.go
+++ b/storage/storage_model.go
@@ -73,7 +73,7 @@ func testIdFromKey(path string) (string, error) {
 	if strings.Contains(path, "/tests/") && len(keyParts) >= 5 {
 		return keyParts[4], nil
 	}
-	return "", errors.Errorf("programmatic error: unexpected test ID prefix in path %s", path)
+	return "", errors.Errorf("programmatic error: unexpected test ID prefix in path '%s'", path)
 }
 
 func buildPrefix(buildID string) string {

--- a/storage/storage_model.go
+++ b/storage/storage_model.go
@@ -70,8 +70,8 @@ func (info *LogChunkInfo) fromKey(path string) error {
 
 func testIdFromKey(path string) (string, error) {
 	keyParts := strings.Split(path, "/")
-	if strings.Contains(path, "/tests/") && len(keyParts) >= 4 {
-		return keyParts[3], nil
+	if strings.Contains(path, "/tests/") && len(keyParts) >= 5 {
+		return keyParts[4], nil
 	}
 	return "", errors.Errorf("Path %s does not contain a well-formed test id prefix", path)
 }
@@ -81,11 +81,11 @@ func buildPrefix(buildID string) string {
 }
 
 func buildTestsPrefix(buildID string) string {
-	return fmt.Sprintf("/%s/tests/", buildID)
+	return fmt.Sprintf("%stests/", buildPrefix(buildID))
 }
 
 func testPrefix(buildID, testID string) string {
-	return fmt.Sprintf("%stests/%s/", buildPrefix(buildID), testID)
+	return fmt.Sprintf("%s%s/", buildTestsPrefix(buildID), testID)
 }
 
 type buildMetadata struct {

--- a/storage/storage_model.go
+++ b/storage/storage_model.go
@@ -73,7 +73,7 @@ func testIdFromKey(path string) (string, error) {
 	if strings.Contains(path, "/tests/") && len(keyParts) >= 5 {
 		return keyParts[4], nil
 	}
-	return "", errors.Errorf("Path %s does not contain a well-formed test id prefix", path)
+	return "", errors.Errorf("programmatic error: unexpected test ID prefix in path %s", path)
 }
 
 func buildPrefix(buildID string) string {

--- a/storage/storage_model.go
+++ b/storage/storage_model.go
@@ -68,8 +68,20 @@ func (info *LogChunkInfo) fromKey(path string) error {
 	return nil
 }
 
+func testIdFromKey(path string) (string, error) {
+	keyParts := strings.Split(path, "/")
+	if strings.Contains(path, "/tests/") && len(keyParts) >= 4 {
+		return keyParts[3], nil
+	}
+	return "", errors.Errorf("Path %s does not contain a well-formed test id prefix", path)
+}
+
 func buildPrefix(buildID string) string {
 	return fmt.Sprintf("/builds/%s/", buildID)
+}
+
+func buildTestsPrefix(buildID string) string {
+	return fmt.Sprintf("/%s/tests/", buildID)
 }
 
 func testPrefix(buildID, testID string) string {

--- a/views.go
+++ b/views.go
@@ -334,16 +334,20 @@ func (lk *logKeeper) viewBuildByIdInS3(r *http.Request, buildID string) (*model.
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	var build *model.Build
-	var buildErr error
+	var (
+		build    *model.Build
+		buildErr error
+	)
 	go func() {
 		defer recovery.LogStackTraceAndContinue("fetching build from s3 for test id")
 		defer wg.Done()
 		build, buildErr = lk.opts.Bucket.FindBuildByID(r.Context(), buildID)
 	}()
 
-	var tests []model.Test
-	var testsErr error
+	var (
+		tests    []model.Test
+		testsErr error
+	)
 	go func() {
 		defer recovery.LogStackTraceAndContinue("fetching build from s3 for test id")
 		defer wg.Done()


### PR DESCRIPTION
This follows the same pattern of "provide the 's3' query parameter to get the build from S3, which we will use for testing once all the data has been replicated to both places.