### PR TITLE
EVG-17467 marshal/unmarshal LogLine

### DIFF
--- a/model/log.go
+++ b/model/log.go
@@ -287,7 +287,7 @@ func (ll *LogLine) SetBSON(raw bson.Raw) error {
 
 	time, ok := line[0].(time.Time)
 	if !ok {
-		return errors.Errorf("timestamp was of unexpected type '%T'", line[0])
+		return errors.Errorf("timestamp was of unexpected type %T", line[0])
 	}
 
 	msg, ok := line[1].(string)

--- a/model/log.go
+++ b/model/log.go
@@ -3,6 +3,7 @@ package model
 import (
 	"encoding/json"
 	"math"
+	"reflect"
 	"regexp"
 	"time"
 
@@ -259,6 +260,43 @@ func (ll *LogLine) UnmarshalJSON(data []byte) error {
 	ll.Time = time.Unix(int64(timeField), nSecPart)
 	ll.Msg = line[1].(string)
 
+	return nil
+}
+
+// GetBSON implements the bson.Getter interface.
+// When a LogLine is marshalled to BSON the driver will marshal the output
+// of this function instead of the struct.
+func (ll LogLine) GetBSON() (interface{}, error) {
+	return []interface{}{ll.Time, ll.Msg}, nil
+}
+
+// SetBSON implements the bson.Setter interface.
+// When a LogLine is unmarshalled from BSON the driver will call this function to
+// unmarshal into the LogLine.
+func (ll *LogLine) SetBSON(raw bson.Raw) error {
+	line := []interface{}{}
+	if err := raw.Unmarshal(&line); err != nil {
+		return &bson.TypeError{
+			Kind: raw.Kind,
+			Type: reflect.TypeOf(line),
+		}
+	}
+	if len(line) < 2 {
+		return errors.Errorf("line was of unexpected length %d", len(line))
+	}
+
+	time, ok := line[0].(time.Time)
+	if !ok {
+		return errors.Errorf("timestamp was of unexpected type '%T'", line[0])
+	}
+
+	msg, ok := line[1].(string)
+	if !ok {
+		return errors.Errorf("message was of unexpected type '%T'", line[1])
+	}
+
+	ll.Time = time.UTC()
+	ll.Msg = msg
 	return nil
 }
 


### PR DESCRIPTION
[EVG-17467](https://jira.mongodb.org/browse/EVG-17467)

Since https://github.com/evergreen-ci/logkeeper/commit/cb88682ab734bf7b06f86d67dae87c230df17b92 a LogLine was getting marshalled to/from BSON as an object. This isn't compatible with existing logs.

Implement the [Getter](https://pkg.go.dev/gopkg.in/mgo.v2@v2.0.0-20190816093944-a6b53ec6cb22/bson#Getter) and [Setter](https://pkg.go.dev/gopkg.in/mgo.v2@v2.0.0-20190816093944-a6b53ec6cb22/bson#Setter) interfaces so the driver will marshal/unmarshal in the original format. Test `GetBSON` by verifying that LogLine is marshalled into the db is as expected and test `SetBSON` by verifying that a LogLine is unmarshalled from the db.