### PR TITLE
EVG-17492: Continue to store command and phase in metadata.json

### DIFF
--- a/storage/persistence_test.go
+++ b/storage/persistence_test.go
@@ -40,6 +40,8 @@ func TestUploadTestMetadata(t *testing.T) {
 		BuildId: "5a75f537726934e4b62833ab6d5dca41",
 		Name:    "test0",
 		Info:    model.TestInfo{TaskID: "t0"},
+		Phase:   "phase0",
+		Command: "command0",
 	}
 
 	assert.NoError(t, storage.UploadTestMetadata(context.Background(), test))
@@ -48,6 +50,6 @@ func TestUploadTestMetadata(t *testing.T) {
 	contents, err := io.ReadAll(results)
 	assert.NoError(t, err)
 
-	expectedMetadata := `{"id":"62dba0159041307f697e6ccc","name":"test0","build_id":"5a75f537726934e4b62833ab6d5dca41","task_id":"t0"}`
+	expectedMetadata := `{"id":"62dba0159041307f697e6ccc","name":"test0","build_id":"5a75f537726934e4b62833ab6d5dca41","task_id":"t0","phase":"phase0", "command":"command0"}`
 	assert.JSONEq(t, expectedMetadata, string(contents))
 }

--- a/storage/retrieval_test.go
+++ b/storage/retrieval_test.go
@@ -191,6 +191,8 @@ func TestFindTestById(t *testing.T) {
 		Info: model.TestInfo{
 			TaskID: "mongodb_mongo_master_enterprise_rhel_80_64_bit_multiversion_all_feature_flags_retryable_writes_downgrade_last_continuous_2_enterprise_f98b3361fbab4e02683325cc0e6ebaa69d6af1df_22_07_22_11_24_37",
 		},
+		Phase:   "phase0",
+		Command: "command0",
 	}
 	testResponse, err := storage.FindTestByID(context.Background(), "5a75f537726934e4b62833ab6d5dca41", "62dba0159041307f697e6ccc")
 	require.NoError(t, err)

--- a/storage/storage_model.go
+++ b/storage/storage_model.go
@@ -125,6 +125,8 @@ type testMetadata struct {
 	Name    string `json:"name"`
 	BuildID string `json:"build_id"`
 	TaskID  string `json:"task_id"`
+	Phase   string `json:"phase"`
+	Command string `json:"command"`
 }
 
 func newTestMetadata(t model.Test) testMetadata {
@@ -133,6 +135,8 @@ func newTestMetadata(t model.Test) testMetadata {
 		BuildID: t.BuildId,
 		Name:    t.Name,
 		TaskID:  t.Info.TaskID,
+		Phase:   t.Phase,
+		Command: t.Command,
 	}
 }
 
@@ -144,6 +148,8 @@ func (m *testMetadata) toTest() model.Test {
 		Info: model.TestInfo{
 			TaskID: m.TaskID,
 		},
+		Phase:   m.Phase,
+		Command: m.Command,
 	}
 }
 

--- a/storage/storage_model_test.go
+++ b/storage/storage_model_test.go
@@ -67,6 +67,8 @@ func TestTestMetadataKey(t *testing.T) {
 		Name:    "name",
 		BuildID: "build0",
 		TaskID:  "t0",
+		Phase:   "phase0",
+		Command: "command0",
 	}
 	assert.Equal(t, "/builds/build0/tests/test0/metadata.json", metadata.key())
 }
@@ -77,8 +79,10 @@ func TestTestMetadataJSON(t *testing.T) {
 		Name:    "name",
 		BuildID: "build0",
 		TaskID:  "t0",
+		Phase:   "phase0",
+		Command: "command0",
 	}
 	json, err := metadata.toJSON()
 	assert.NoError(t, err)
-	assert.Equal(t, `{"id":"test0","name":"name","build_id":"build0","task_id":"t0"}`, string(json))
+	assert.Equal(t, `{"id":"test0","name":"name","build_id":"build0","task_id":"t0","phase":"phase0","command":"command0"}`, string(json))
 }

--- a/testdata/between/builds/5a75f537726934e4b62833ab6d5dca41/tests/62dba0159041307f697e6ccc/metadata.json
+++ b/testdata/between/builds/5a75f537726934e4b62833ab6d5dca41/tests/62dba0159041307f697e6ccc/metadata.json
@@ -2,5 +2,7 @@
     "id": "62dba0159041307f697e6ccc",
     "build_id": "5a75f537726934e4b62833ab6d5dca41",
     "name": "geo_max:CheckReplOplogs",
-    "task_id": "Task"
+    "task_id": "Task",
+    "phase": "phase0",
+    "command": "command0"
 }

--- a/testdata/between/builds/5a75f537726934e4b62833ab6d5dca41/tests/72dba0159041307f697e6ccd/metadata.json
+++ b/testdata/between/builds/5a75f537726934e4b62833ab6d5dca41/tests/72dba0159041307f697e6ccd/metadata.json
@@ -2,5 +2,7 @@
     "id": "72dba0159041307f697e6ccd",
     "build_id": "5a75f537726934e4b62833ab6d5dca41",
     "name": "geo_max:CheckReplOplogs2",
-    "task_id": "Task"
+    "task_id": "Task",
+    "phase": "phase1",
+    "command": "command1"
 }

--- a/testdata/overlapping/builds/5a75f537726934e4b62833ab6d5dca41/tests/62dba0159041307f697e6ccc/metadata.json
+++ b/testdata/overlapping/builds/5a75f537726934e4b62833ab6d5dca41/tests/62dba0159041307f697e6ccc/metadata.json
@@ -2,5 +2,7 @@
     "id": "62dba0159041307f697e6ccc",
     "build_id": "5a75f537726934e4b62833ab6d5dca41",
     "name": "geo_max:CheckReplOplogs",
-    "task_id": "Task"
+    "task_id": "Task",
+    "phase": "phase0",
+    "command": "command0"
 }

--- a/testdata/simple/builds/5a75f537726934e4b62833ab6d5dca41/tests/62dba0159041307f697e6ccc/metadata.json
+++ b/testdata/simple/builds/5a75f537726934e4b62833ab6d5dca41/tests/62dba0159041307f697e6ccc/metadata.json
@@ -2,5 +2,7 @@
     "id": "62dba0159041307f697e6ccc",
     "build_id": "5a75f537726934e4b62833ab6d5dca41",
     "name": "geo_max:CheckReplOplogs",
-    "task_id": "mongodb_mongo_master_enterprise_rhel_80_64_bit_multiversion_all_feature_flags_retryable_writes_downgrade_last_continuous_2_enterprise_f98b3361fbab4e02683325cc0e6ebaa69d6af1df_22_07_22_11_24_37"
+    "task_id": "mongodb_mongo_master_enterprise_rhel_80_64_bit_multiversion_all_feature_flags_retryable_writes_downgrade_last_continuous_2_enterprise_f98b3361fbab4e02683325cc0e6ebaa69d6af1df_22_07_22_11_24_37",
+    "phase": "phase0",
+    "command": "command0"
 }


### PR DESCRIPTION
We should keep storing metadata and phase since clients are passing
it and may want it back, even though we don't currently use it
in the code base. We would like to minimize data model changes
for our project.