### PR TITLE
EVG-17493: Generate build keys from builder and buildNum.

### DIFF
--- a/model/build.go
+++ b/model/build.go
@@ -168,7 +168,7 @@ func NewBuildId(builder string, buildNum int) (string, error) {
 		return "", errors.Wrap(err, "generating json to hash for build key")
 	}
 
-	if _, err := hasher.Write([]byte(hashstring)); err != nil {
+	if _, err := hasher.Write(hashstring); err != nil {
 		return "", errors.Wrap(err, "hashing json for build key")
 	}
 

--- a/model/build.go
+++ b/model/build.go
@@ -1,10 +1,12 @@
 package model
 
 import (
+	"bytes"
 	"context"
 	"crypto/md5"
+	"encoding/binary"
 	"encoding/hex"
-	"encoding/json"
+	"strconv"
 	"time"
 
 	"github.com/evergreen-ci/logkeeper/db"
@@ -153,22 +155,29 @@ func RemoveBuild(buildID string) error {
 	return errors.Wrap(db.C(BuildsCollection).RemoveId(buildID), "deleting build record")
 }
 
+const (
+	builderFieldNum  = 1
+	buildNumFieldNum = 2
+)
+
+func makeBinaryRepresentation(builder string, buildNum int) []byte {
+	var buf bytes.Buffer
+	builderBytes := []byte(builder)
+	buildNumBytes := []byte(strconv.Itoa(buildNum))
+	binary.Write(&buf, binary.BigEndian, uint32(builderFieldNum))
+	binary.Write(&buf, binary.BigEndian, uint32(len(builderBytes)))
+	buf.Write(builderBytes)
+	binary.Write(&buf, binary.BigEndian, uint32(buildNumFieldNum))
+	binary.Write(&buf, binary.BigEndian, uint32(len(buildNumBytes)))
+	buf.Write(buildNumBytes)
+	return buf.Bytes()
+}
+
 // Generates a new build ID based on the hash of builder and buildNum
 func NewBuildId(builder string, buildNum int) (string, error) {
 	hasher := md5.New()
 
-	// This depends on the fact that Go's json implementation sorts json keys
-	// lexicographically for maps, which ensures consistent encoding
-	jsonMap := make(map[string]interface{})
-	jsonMap["builder"] = builder
-	jsonMap["buildNum"] = buildNum
-	hashstring, err := json.Marshal(jsonMap)
-
-	if err != nil {
-		return "", errors.Wrap(err, "generating json to hash for build key")
-	}
-
-	if _, err := hasher.Write(hashstring); err != nil {
+	if _, err := hasher.Write(makeBinaryRepresentation(builder, buildNum)); err != nil {
 		return "", errors.Wrap(err, "hashing json for build key")
 	}
 

--- a/model/build_test.go
+++ b/model/build_test.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"context"
-	"encoding/hex"
 	"testing"
 	"time"
 
@@ -133,34 +132,24 @@ func TestStreamingGetOldBuilds(t *testing.T) {
 	assert.Equal(t, oldBuild.Id, builds[0].Id)
 }
 
-func TestMakeBinaryRepresntation(t *testing.T) {
-	result := makeBinaryRepresentation("", 0)
-	expected := "0000000100000000000000020000000130"
-	assert.Equal(t, expected, hex.EncodeToString(result))
-
-	result = makeBinaryRepresentation("ABCD", 1000)
-	expected = "000000010000000441424344000000020000000431303030"
-	assert.Equal(t, expected, hex.EncodeToString(result))
-}
-
 func TestNewBuildId(t *testing.T) {
 	result, err := NewBuildId("A", 123)
 	require.NoError(t, err)
-	assert.Equal(t, "b9780338910c8b3b334aca46e8900461", result)
+	assert.Equal(t, "1e7747b3e13274f0bee0de868c8314c9", result)
 
 	result, err = NewBuildId("", -10000)
 	require.NoError(t, err)
-	assert.Equal(t, "8e2770c7334ee6a68db91c6c6fb4e021", result)
+	assert.Equal(t, "7d2e3a33d801c1ac74f062b41c977104", result)
 
 	result, err = NewBuildId(`{"builder": "builder", "buildNum": "1000"}`, 0)
 	require.NoError(t, err)
-	assert.Equal(t, "9a464e195ff3d4776155e4a25c38adbd", result)
+	assert.Equal(t, "ed39e8e7310193625e521204242e80c4", result)
 
 	result, err = NewBuildId("10", 100)
 	require.NoError(t, err)
-	assert.Equal(t, "3a6d7d3f631b9c919c7ef5ac5347092f", result)
+	assert.Equal(t, "f4088565508a32f3e6ff9205408bcce9", result)
 
 	result, err = NewBuildId("100", 10)
 	require.NoError(t, err)
-	assert.Equal(t, "e2d6aaf175e192b4e51cf850bb3a3fad", result)
+	assert.Equal(t, "b2f7b29a7f76e38abe38fc8145c0cf98", result)
 }

--- a/model/build_test.go
+++ b/model/build_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"encoding/hex"
 	"testing"
 	"time"
 
@@ -132,24 +133,34 @@ func TestStreamingGetOldBuilds(t *testing.T) {
 	assert.Equal(t, oldBuild.Id, builds[0].Id)
 }
 
+func TestMakeBinaryRepresntation(t *testing.T) {
+	result := makeBinaryRepresentation("", 0)
+	expected := "0000000100000000000000020000000130"
+	assert.Equal(t, expected, hex.EncodeToString(result))
+
+	result = makeBinaryRepresentation("ABCD", 1000)
+	expected = "000000010000000441424344000000020000000431303030"
+	assert.Equal(t, expected, hex.EncodeToString(result))
+}
+
 func TestNewBuildId(t *testing.T) {
 	result, err := NewBuildId("A", 123)
 	require.NoError(t, err)
-	assert.Equal(t, "1e7747b3e13274f0bee0de868c8314c9", result)
+	assert.Equal(t, "b9780338910c8b3b334aca46e8900461", result)
 
 	result, err = NewBuildId("", -10000)
 	require.NoError(t, err)
-	assert.Equal(t, "7d2e3a33d801c1ac74f062b41c977104", result)
+	assert.Equal(t, "8e2770c7334ee6a68db91c6c6fb4e021", result)
 
 	result, err = NewBuildId(`{"builder": "builder", "buildNum": "1000"}`, 0)
 	require.NoError(t, err)
-	assert.Equal(t, "ed39e8e7310193625e521204242e80c4", result)
+	assert.Equal(t, "9a464e195ff3d4776155e4a25c38adbd", result)
 
 	result, err = NewBuildId("10", 100)
 	require.NoError(t, err)
-	assert.Equal(t, "f4088565508a32f3e6ff9205408bcce9", result)
+	assert.Equal(t, "3a6d7d3f631b9c919c7ef5ac5347092f", result)
 
 	result, err = NewBuildId("100", 10)
 	require.NoError(t, err)
-	assert.Equal(t, "b2f7b29a7f76e38abe38fc8145c0cf98", result)
+	assert.Equal(t, "e2d6aaf175e192b4e51cf850bb3a3fad", result)
 }

--- a/model/build_test.go
+++ b/model/build_test.go
@@ -131,3 +131,25 @@ func TestStreamingGetOldBuilds(t *testing.T) {
 	require.Len(t, builds, 1)
 	assert.Equal(t, oldBuild.Id, builds[0].Id)
 }
+
+func TestNewBuildId(t *testing.T) {
+	result, err := NewBuildId("A", 123)
+	require.NoError(t, err)
+	assert.Equal(t, "1e7747b3e13274f0bee0de868c8314c9", result)
+
+	result, err = NewBuildId("", -10000)
+	require.NoError(t, err)
+	assert.Equal(t, "7d2e3a33d801c1ac74f062b41c977104", result)
+
+	result, err = NewBuildId(`{"builder": "builder", "buildNum": "1000"}`, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "ed39e8e7310193625e521204242e80c4", result)
+
+	result, err = NewBuildId("10", 100)
+	require.NoError(t, err)
+	assert.Equal(t, "f4088565508a32f3e6ff9205408bcce9", result)
+
+	result, err = NewBuildId("100", 10)
+	require.NoError(t, err)
+	assert.Equal(t, "b2f7b29a7f76e38abe38fc8145c0cf98", result)
+}

--- a/views.go
+++ b/views.go
@@ -1,8 +1,6 @@
 package logkeeper
 
 import (
-	"crypto/md5"
-	"encoding/hex"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -110,13 +108,12 @@ func (lk *logKeeper) createBuild(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hasher := md5.New()
-	if _, err = hasher.Write([]byte(bson.NewObjectId().Hex())); err != nil {
+	newBuildId, err := model.NewBuildId(buildParameters.Builder, buildParameters.BuildNum)
+	if err != nil {
 		lk.render.WriteJSON(w, http.StatusInternalServerError, apiError{Err: err.Error()})
 		return
 	}
 
-	newBuildId := hex.EncodeToString(hasher.Sum(nil))
 	newBuild := model.Build{
 		Id:       newBuildId,
 		Builder:  buildParameters.Builder,


### PR DESCRIPTION
This will allow us to constant time lookup builds based on
builder and buildNum without having to add an additional S3
hierarchy.