### PR TITLE
EVG-17461 use S3 bucket again

### DIFF
--- a/main/logkeeper.go
+++ b/main/logkeeper.go
@@ -35,7 +35,7 @@ func main() {
 	dbHost := flag.String("dbhost", "localhost:27017", "host/port to connect to DB server. Comma separated.")
 	rsName := flag.String("rsName", "", "name of replica set that the DB instances belong to. "+
 		"Leave empty for stand-alone and mongos instances.")
-	localPath := flag.String("localPath", "_bucketdata", "local path to save data to")
+	localPath := flag.String("localPath", "", "local path to save data to. Omit to save data to S3.")
 	logPath := flag.String("logpath", "logkeeperapp.log", "path to log file")
 	maxRequestSize := flag.Int("maxRequestSize", 1024*1024*32,
 		"maximum size for a request in bytes, defaults to 32 MB (in bytes)")

--- a/makefile
+++ b/makefile
@@ -4,6 +4,7 @@ buildDir := build
 packages := $(name) storage model
 orgPath := github.com/evergreen-ci
 projectPath := $(orgPath)/$(name)
+tempStorageDir := _bucketdata
 
 # end project configuration
 
@@ -122,7 +123,7 @@ $(buildDir)/output.%.coverage: .FORCE
 $(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
 	go tool cover -html=$< -o $@
 $(buildDir)/output.smoke.test: $(buildDir)/$(name)
-	./$< &
+	./$< --localPath $(tempStorageDir) &
 	PORT=8080 go test $(testArgs) -v ./smoke/smoke_test.go | tee $(buildDir)/output.smoke.test || (pkill -f $<; exit 1)
 	pkill -f $<
 # end test and coverage artifacts


### PR DESCRIPTION
[EVG-17461](https://jira.mongodb.org/browse/EVG-17461)
Revert the change we made in https://github.com/evergreen-ci/logkeeper/pull/88 and go back to using the S3 bucket. 

This is dependent on the changes to the fabfile to create an environment file and the changes to the chef configuration to use the environment file. Don't merge this until those are in place.