### PR TITLE
EVG-17160: Add featureswitch code for writing builds.

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -155,6 +155,10 @@ tasks:
     name: test-storage
     exec_timeout_secs: 900
     tags: ["test"]
+  - <<: *run-test
+    name: test-featureswitch
+    exec_timeout_secs: 900
+    tags: ["test"]
   - <<: *run-test-mongodb
     name: test-logkeeper
     exec_timeout_secs: 900

--- a/featureswitch/featureswitch.go
+++ b/featureswitch/featureswitch.go
@@ -1,0 +1,55 @@
+package featureswitch
+
+import (
+	"crypto/md5"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"os"
+	"strconv"
+
+	"github.com/mongodb/grip"
+)
+
+const s3WriteFeatureSwitch = "LK_WRITE_S3_FEATURE_SWITCH"
+
+func hashToFloat(hash []byte) float64 {
+	value := binary.BigEndian.Uint32(hash[:4])
+	// The plus one ensures that we return a number in the range 0 to 1,
+	// inclusive of 0 and exclusive of 1.
+	return float64(value) / (math.MaxUint32 + 1)
+}
+
+func getThreshold(featureSwitch string) float64 {
+	value := os.Getenv(featureSwitch)
+	floatValue, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		// If we don't have a parseable feature flag just log the error and return 0.
+		// Our callers can't do anything about an unparseable feature flag.
+		grip.Error(fmt.Sprintf("getting feature flag '%s'", featureSwitch))
+		return 0
+	} else {
+		return floatValue
+	}
+}
+
+func matchesFeatureForHash(featureSwitch string, hash []byte) bool {
+	value := hashToFloat(hash)
+	threshold := getThreshold(featureSwitch)
+	// value is guaranteed to be in the range [0, 1), which means that
+	// '<' will always return false for a threshold of 0 and always return
+	// true for a threshold of 1.0.
+	return value < threshold
+}
+
+func matchesFeatureForString(featureSwitch string, data string) bool {
+	hasher := md5.New()
+	hasher.Write([]byte(featureSwitch))
+	hasher.Write([]byte(data))
+	hash := hasher.Sum(nil)
+	return matchesFeatureForHash(featureSwitch, hash)
+}
+
+func WriteToS3Enabled(buildID string) bool {
+	return matchesFeatureForString(s3WriteFeatureSwitch, buildID)
+}

--- a/featureswitch/featureswitch_test.go
+++ b/featureswitch/featureswitch_test.go
@@ -1,0 +1,96 @@
+package featureswitch
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashToFloat(t *testing.T) {
+	actual := hashToFloat([]byte{0xff, 0xff, 0xff, 0xff, 0x01})
+	assert.InDelta(t, actual, 1.0, 0.00001, "Max hash should be very close to one")
+	assert.Less(t, actual, 1.0, "Max hash should still be less than one")
+
+	actual = hashToFloat([]byte{0x80, 0x00, 0x00, 0x00, 0x00})
+	assert.Equal(t, 0.5, actual)
+
+	actual = hashToFloat([]byte{0x00, 0x00, 0x00, 0x00, 0x01})
+	assert.Equal(t, 0.0, actual, "Min hash should be exactly 0")
+}
+
+func TestMatchesFeatureForHash(t *testing.T) {
+	defer os.Clearenv()
+
+	os.Clearenv()
+	require.NoError(t, os.Setenv(s3WriteFeatureSwitch, "1.0"))
+
+	actual := matchesFeatureForHash(s3WriteFeatureSwitch, []byte{0xff, 0xff, 0xff, 0xff, 0x01})
+	assert.Equal(t, true, actual)
+
+	actual = matchesFeatureForHash(s3WriteFeatureSwitch, []byte{0x00, 0x00, 0x00, 0x00, 0x01})
+	assert.Equal(t, true, actual)
+
+	require.NoError(t, os.Setenv(s3WriteFeatureSwitch, "0.0"))
+	actual = matchesFeatureForHash(s3WriteFeatureSwitch, []byte{0xff, 0xff, 0xff, 0xff, 0x01})
+	assert.Equal(t, false, actual)
+
+	actual = matchesFeatureForHash(s3WriteFeatureSwitch, []byte{0x00, 0x00, 0x00, 0x00, 0x01})
+	assert.Equal(t, false, actual)
+
+	require.NoError(t, os.Setenv(s3WriteFeatureSwitch, "0.5"))
+	actual = matchesFeatureForHash(s3WriteFeatureSwitch, []byte{0x80, 0x00, 0x00, 0x00, 0x00})
+	assert.Equal(t, false, actual)
+
+	actual = matchesFeatureForHash(s3WriteFeatureSwitch, []byte{0x7f, 0xff, 0xff, 0xff, 0x00})
+	assert.Equal(t, true, actual)
+}
+
+func TestMatchesFeatureForString(t *testing.T) {
+	defer os.Clearenv()
+
+	os.Clearenv()
+	require.NoError(t, os.Setenv(s3WriteFeatureSwitch, "1.0"))
+
+	actual := matchesFeatureForString(s3WriteFeatureSwitch, "A string")
+	assert.Equal(t, true, actual)
+
+	require.NoError(t, os.Setenv(s3WriteFeatureSwitch, "0.0"))
+	actual = matchesFeatureForString(s3WriteFeatureSwitch, "A string")
+	assert.Equal(t, false, actual)
+}
+
+func TestGetThreshold(t *testing.T) {
+	defer os.Clearenv()
+
+	t.Run("MissingFlag", func(t *testing.T) {
+		os.Clearenv()
+		threshold := getThreshold("NONEXISTENT")
+		assert.Equal(t, 0.0, threshold)
+	})
+
+	t.Run("InvalidFlag", func(t *testing.T) {
+		os.Clearenv()
+
+		require.NoError(t, os.Setenv(s3WriteFeatureSwitch, "NoNumber"))
+		threshold := getThreshold(s3WriteFeatureSwitch)
+		assert.Equal(t, 0.0, threshold)
+	})
+
+	t.Run("ZeroFlag", func(t *testing.T) {
+		os.Clearenv()
+		require.NoError(t, os.Setenv(s3WriteFeatureSwitch, "0"))
+
+		threshold := getThreshold(s3WriteFeatureSwitch)
+		assert.Equal(t, 0.0, threshold)
+	})
+
+	t.Run("OneFlag", func(t *testing.T) {
+		os.Clearenv()
+		require.NoError(t, os.Setenv(s3WriteFeatureSwitch, "1.0"))
+
+		threshold := getThreshold(s3WriteFeatureSwitch)
+		assert.Equal(t, 1.0, threshold)
+	})
+}

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 # start project configuration
 name := logkeeper
 buildDir := build
-packages := $(name) storage model
+packages := $(name) storage model featureswitch
 orgPath := github.com/evergreen-ci
 projectPath := $(orgPath)/$(name)
 


### PR DESCRIPTION
This will allow us to set a percentage of builds being written to
S3. I opted to make this a hash of the build ID rather than random
for a few reasons:

1. When we use this for ramping up fetching from S3, it will ensure
that users won't alternate between code paths for fetching the same
build. This should avoid weird bugs for clients and aid in
debugging.
2. It will make debugging in general less based on chance. If you
put the same build name and id to the same configuration, you'll
hit the same code path.