### PR TITLE
EVG-17461 check for empty string

### DIFF
--- a/main/logkeeper.go
+++ b/main/logkeeper.go
@@ -171,7 +171,7 @@ func gracefulShutdownForSIGTERM(ctx context.Context, servers []*http.Server, gra
 }
 
 func makeBucket(localPath *string) (storage.Bucket, error) {
-	if localPath != nil {
+	if *localPath != "" {
 		return storage.NewBucket(storage.BucketOpts{
 			Location: storage.PailLocal,
 			Path:     *localPath,


### PR DESCRIPTION
[EVG-17461](https://jira.mongodb.org/browse/EVG-17461)

I made a wrong assumption about [flag.String](https://github.com/evergreen-ci/logkeeper/blob/b108605d58a90c8c17d7d641b45419f5e5736a45/main/logkeeper.go#L38): the returned string pointer is never nil. If the flag isn't specified the return is always set to whatever the default value is, in this case the empty string.