### PR TITLE
EVG-17426: Switch to not prefixing our keys with '/'

### DIFF
--- a/storage/storage_model.go
+++ b/storage/storage_model.go
@@ -56,12 +56,18 @@ func (info *LogChunkInfo) fromKey(path string) error {
 	var keyName string
 	keyParts := strings.Split(path, "/")
 	if strings.Contains(path, "/tests/") {
-		info.BuildID = keyParts[2]
-		info.TestID = keyParts[4]
-		keyName = keyParts[5]
+		if len(keyParts) < 5 {
+			return errors.Errorf("invalid chunk key '%s'", path)
+		}
+		info.BuildID = keyParts[1]
+		info.TestID = keyParts[3]
+		keyName = keyParts[4]
 	} else {
-		info.BuildID = keyParts[2]
-		keyName = keyParts[3]
+		if len(keyParts) < 3 {
+			return errors.Errorf("invalid chunk key '%s'", path)
+		}
+		info.BuildID = keyParts[1]
+		keyName = keyParts[2]
 	}
 
 	nameParts := strings.Split(keyName, "_")
@@ -111,13 +117,13 @@ func (info *LogChunkInfo) fromLogChunk(buildID string, testID string, logChunk m
 func testIDFromKey(path string) (string, error) {
 	keyParts := strings.Split(path, "/")
 	if strings.Contains(path, "/tests/") && len(keyParts) >= 5 {
-		return keyParts[4], nil
+		return keyParts[3], nil
 	}
 	return "", errors.Errorf("programmatic error: unexpected test ID prefix in path '%s'", path)
 }
 
 func buildPrefix(buildID string) string {
-	return fmt.Sprintf("/builds/%s/", buildID)
+	return fmt.Sprintf("builds/%s/", buildID)
 }
 
 func buildTestsPrefix(buildID string) string {

--- a/storage/storage_model_test.go
+++ b/storage/storage_model_test.go
@@ -17,10 +17,13 @@ func TestLogChunkInfoKey(t *testing.T) {
 			End:      time.Date(2009, time.November, 10, 23, 1, 0, 0, time.UTC),
 		}
 		key := info.key()
-		assert.Equal(t, "/builds/b0/tests/t0/1257894000000000000_1257894060000000000_1", key)
+		assert.Equal(t, "builds/b0/tests/t0/1257894000000000000_1257894060000000000_1", key)
 		newInfo := LogChunkInfo{}
 		assert.NoError(t, newInfo.fromKey(key))
 		assert.Equal(t, info, newInfo)
+		parsedTestId, err := testIDFromKey(key)
+		assert.NoError(t, err)
+		assert.Equal(t, info.TestID, parsedTestId)
 	})
 
 	t.Run("WithoutTest", func(t *testing.T) {
@@ -31,12 +34,25 @@ func TestLogChunkInfoKey(t *testing.T) {
 			End:      time.Date(2009, time.November, 10, 23, 1, 0, 0, time.UTC),
 		}
 		key := info.key()
-		assert.Equal(t, "/builds/b0/1257894000000000000_1257894060000000000_1", key)
+		assert.Equal(t, "builds/b0/1257894000000000000_1257894060000000000_1", key)
 		newInfo := LogChunkInfo{}
 		assert.NoError(t, newInfo.fromKey(key))
 		assert.Equal(t, info, newInfo)
-	})
 
+		_, err := testIDFromKey(key)
+		assert.Error(t, err)
+	})
+}
+
+func TestFromKey(t *testing.T) {
+	t.Run("InvalidKey", func(t *testing.T) {
+		newInfo := LogChunkInfo{}
+		assert.NotPanics(t, func() {
+			err := newInfo.fromKey("asdf")
+			assert.Error(t, err)
+		})
+
+	})
 }
 
 func TestBuildMetadataKey(t *testing.T) {
@@ -46,7 +62,7 @@ func TestBuildMetadataKey(t *testing.T) {
 		BuildNum: 1,
 		TaskID:   "t0",
 	}
-	assert.Equal(t, "/builds/b0/metadata.json", metadata.key())
+	assert.Equal(t, "builds/b0/metadata.json", metadata.key())
 }
 
 func TestBuildMetadataJSON(t *testing.T) {
@@ -70,7 +86,7 @@ func TestTestMetadataKey(t *testing.T) {
 		Phase:   "phase0",
 		Command: "command0",
 	}
-	assert.Equal(t, "/builds/build0/tests/test0/metadata.json", metadata.key())
+	assert.Equal(t, "builds/build0/tests/test0/metadata.json", metadata.key())
 }
 
 func TestTestMetadataJSON(t *testing.T) {


### PR DESCRIPTION
This plays better with all the S3 APIs, since AWS likes to
strip double slashes, including those in REST requests that
correspond to the beginning of a key value.