### PR TITLE
EVG-17602, EVG-17621: Parallelize and independently write to S3

### DIFF
--- a/storage/persistence.go
+++ b/storage/persistence.go
@@ -33,7 +33,7 @@ func (b *Bucket) UploadTestMetadata(ctx context.Context, test model.Test) error 
 }
 
 // InsertLogChunks uploads a new chunk of logs for a given build or test to the
-// offline blob bucket storage. If a test ID is not empty, the logs are
+// offline blob bucket storage. If the test ID is not empty, the logs are
 // appended to the test for the given build, otherwise the logs are appended to
 // the top-level build. A build ID is required in both cases.
 func (b *Bucket) InsertLogChunks(ctx context.Context, buildID string, testID string, chunks []model.LogChunk) error {

--- a/storage/persistence.go
+++ b/storage/persistence.go
@@ -8,6 +8,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+// UploadBuildMetadata uploads metadata for a new build to the offline blob
+// bucket storage.
 func (b *Bucket) UploadBuildMetadata(ctx context.Context, build model.Build) error {
 	metadata := newBuildMetadata(build)
 	json, err := metadata.toJSON()
@@ -18,6 +20,8 @@ func (b *Bucket) UploadBuildMetadata(ctx context.Context, build model.Build) err
 	return errors.Wrapf(b.Put(ctx, metadata.key(), bytes.NewReader(json)), "putting metadata for build '%s'", build.Id)
 }
 
+// UploadBuildMetadata uploads metadata for a new test to the offline blob
+// bucket storage.
 func (b *Bucket) UploadTestMetadata(ctx context.Context, test model.Test) error {
 	metadata := newTestMetadata(test)
 	json, err := metadata.toJSON()
@@ -28,6 +32,8 @@ func (b *Bucket) UploadTestMetadata(ctx context.Context, test model.Test) error 
 	return errors.Wrapf(b.Put(ctx, metadata.key(), bytes.NewReader(json)), "putting metadata for test '%s'", test.Id)
 }
 
+// InsertLogChunks uploads a new chunk of logs for a given build and (optional)
+// test to the offline blob bucket storage.
 func (b *Bucket) InsertLogChunks(ctx context.Context, buildID string, testID string, chunks []model.LogChunk) error {
 	for _, chunk := range chunks {
 		if len(chunk) == 0 {
@@ -42,9 +48,10 @@ func (b *Bucket) InsertLogChunks(ctx context.Context, buildID string, testID str
 		var buffer bytes.Buffer
 		numLines := 0
 		for _, line := range chunk {
-			// We are sometimes passed in a single log line that is actually multiple lines,
-			// so we parse it into separate lines and keep track of the count to make sure
-			// we know the current number of lines.
+			// We are sometimes passed in a single log line that is
+			// actually multiple lines, so we parse it into
+			// separate lines and keep track of the count to make
+			// sure we know the current number of lines.
 			for _, parsedLine := range makeLogLineStrings(line) {
 				buffer.WriteString(parsedLine)
 				numLines += 1
@@ -58,4 +65,29 @@ func (b *Bucket) InsertLogChunks(ctx context.Context, buildID string, testID str
 	}
 
 	return nil
+}
+
+// CheckMetadata returns whether the metadata file exists for the given build
+// and (optional) test.
+func (b *Bucket) CheckMetadata(ctx context.Context, buildID string, testID string) (bool, error) {
+	var key string
+	if testID == "" {
+		key = metadataKeyForBuild(buildID)
+	} else {
+		key = metadataKeyForTest(buildID, testID)
+	}
+
+	iter, err := b.List(ctx, key)
+	if err != nil {
+		return false, errors.Wrap(err, "listing metadata files")
+	}
+
+	for iter.Next(ctx) {
+		// We set the prefix to the entire metadata filename, so
+		// finding a single file in the bucket with the given prefix
+		// suffices.
+		return true, nil
+	}
+
+	return false, errors.Wrap(iter.Err(), "iterating over metadata files")
 }

--- a/storage/persistence_test.go
+++ b/storage/persistence_test.go
@@ -27,7 +27,6 @@ func newExpectedChunk(filename string, lines []string) expectedChunk {
 
 func TestUploadBuildMetadata(t *testing.T) {
 	storage := makeTestStorage(t, "")
-	defer cleanTestStorage(t)
 
 	build := model.Build{
 		Id:       "5a75f537726934e4b62833ab6d5dca41",
@@ -48,7 +47,6 @@ func TestUploadBuildMetadata(t *testing.T) {
 
 func TestUploadTestMetadata(t *testing.T) {
 	storage := makeTestStorage(t, "")
-	defer cleanTestStorage(t)
 
 	test := model.Test{
 		Id:      model.TestID("62dba0159041307f697e6ccc"),
@@ -160,7 +158,6 @@ func TestInsertLogChunks(t *testing.T) {
 
 	t.Run("Global", func(t *testing.T) {
 		storage := makeTestStorage(t, "nolines")
-		defer cleanTestStorage(t)
 
 		err := storage.InsertLogChunks(context.Background(), buildID, "", uploadChunks)
 		require.NoError(t, err)
@@ -181,7 +178,6 @@ func TestInsertLogChunks(t *testing.T) {
 
 	t.Run("Test", func(t *testing.T) {
 		storage := makeTestStorage(t, "nolines")
-		defer cleanTestStorage(t)
 
 		testID := "DE0B6B3A764000000000000"
 

--- a/storage/retrieval.go
+++ b/storage/retrieval.go
@@ -15,7 +15,7 @@ import (
 )
 
 // CheckMetadata returns whether the metadata file exists for the given build
-// or test. If a test ID is not empty, the metadata of the test for the given
+// or test. If the test ID is not empty, the metadata of the test for the given
 // build is checked, otherwise the top-level build metadata is checked. A build
 // ID is required in both cases.
 func (b *Bucket) CheckMetadata(ctx context.Context, buildID string, testID string) (bool, error) {

--- a/storage/retrieval.go
+++ b/storage/retrieval.go
@@ -14,6 +14,33 @@ import (
 	"github.com/pkg/errors"
 )
 
+// CheckMetadata returns whether the metadata file exists for the given build
+// or test. If a test ID is not empty, the metadata of the test for the given
+// build is checked, otherwise the top-level build metadata is checked. A build
+// ID is required in both cases.
+func (b *Bucket) CheckMetadata(ctx context.Context, buildID string, testID string) (bool, error) {
+	var key string
+	if testID == "" {
+		key = metadataKeyForBuild(buildID)
+	} else {
+		key = metadataKeyForTest(buildID, testID)
+	}
+
+	iter, err := b.List(ctx, key)
+	if err != nil {
+		return false, errors.Wrap(err, "listing metadata files")
+	}
+
+	for iter.Next(ctx) {
+		// We set the prefix to the entire metadata filename, so
+		// finding a single file in the bucket with the given prefix
+		// suffices.
+		return true, nil
+	}
+
+	return false, errors.Wrap(iter.Err(), "iterating over metadata files")
+}
+
 // FindBuildByID returns the build metadata for the given ID from the offline
 // blob storage bucket.
 func (b *Bucket) FindBuildByID(ctx context.Context, id string) (*model.Build, error) {

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -10,17 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const tempDir = "../_bucketdata"
-
 func makeTestStorage(t *testing.T, initDir string) Bucket {
-	err := os.RemoveAll(tempDir)
-	require.NoError(t, err)
-	err = os.Mkdir(tempDir, 0755)
-	require.NoError(t, err)
-
 	bucket, err := NewBucket(BucketOpts{
 		Location: PailLocal,
-		Path:     tempDir,
+		Path:     t.TempDir(),
 	})
 	require.NoError(t, err)
 
@@ -35,14 +28,9 @@ func makeTestStorage(t *testing.T, initDir string) Bucket {
 	return bucket
 }
 
-func cleanTestStorage(t *testing.T) {
-	err := os.RemoveAll(tempDir)
-	require.NoError(t, err)
-}
-
 func TestBasicStorage(t *testing.T) {
 	storage := makeTestStorage(t, "../testdata/simple")
-	defer cleanTestStorage(t)
+
 	results, err := storage.Get(context.Background(), "/builds/5a75f537726934e4b62833ab6d5dca41/metadata.json")
 	assert.NoError(t, err)
 	assert.NotEqual(t, nil, results)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-17602, https://jira.mongodb.org/browse/EVG-17621

I made the writes to S3 as independent as possible but we still rely on the `s3` field from the build model when uploading logs and test metadata. This isn't a big deal, though, because when we are ready to remove the DB code we can just ignore it since all writes will go to S3.

I tested that this works in staging.