### PR TITLE
EVG-17902 don't filter test logs

### DIFF
--- a/storage/retrieval.go
+++ b/storage/retrieval.go
@@ -150,7 +150,7 @@ func (b *Bucket) DownloadLogLines(ctx context.Context, buildID string, testID st
 		return nil, errors.Wrapf(err, "getting execution window for test '%s'", testID)
 	}
 
-	return NewMergingIterator(NewBatchedLogIterator(b, testChunks, 4, tr), NewBatchedLogIterator(b, buildChunks, 4, tr)).Stream(ctx), nil
+	return NewMergingIterator(NewBatchedLogIterator(b, testChunks, 4, AllTime), NewBatchedLogIterator(b, buildChunks, 4, tr)).Stream(ctx), nil
 }
 
 // getBuildKeys returns the all the keys contained within the build prefix.


### PR DESCRIPTION
[EVG-17902](https://jira.mongodb.org/browse/EVG-17902)

[The case where we saw tests with no logs](https://logkeeper2.build.10gen.cc/build/a109a76144f2aef17a40a90a3c29e09f/test/171504be6897f79df966b75e5df1e7ac?raw=1&s3=true) was where the next test started even before the first test's first log line's timestamp. 
This test's id is `171504be6897f79df966b75e5df1e7ac` which is this morning at 11:20:53.228 and the next test's id is `171504be68c795914274542da474485b` which is 11:20:53.231. The first log line for this test has a timestamp of 11:20:53.290 which is after the next test started so all the log lines get filtered.

The timestamps are all the same in the DB, but [we don't filter test logs by timestamp](https://github.com/evergreen-ci/logkeeper/blob/b6aa2d5cce564602f67d7806d40fc36f0a66115e/model/log.go#L108) (we pass nil for the boundaries). Let's do the same for S3 logs.