### PR TITLE
EVG-17980 add temporary dbhost flag

### DIFF
--- a/main/logkeeper.go
+++ b/main/logkeeper.go
@@ -29,6 +29,7 @@ func main() {
 	logPath := flag.String("logpath", "logkeeperapp.log", "path to log file")
 	maxRequestSize := flag.Int("maxRequestSize", 1024*1024*32,
 		"maximum size for a request in bytes, defaults to 32 MB (in bytes)")
+	_ = flag.String("dbhost", "", "LEGACY: this option is ignored")
 	flag.Parse()
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
[EVG-17980](https://jira.mongodb.org/browse/EVG-17980)

If we remove the option before we remove it from the systemd unit file then the application will not start. If we remove it from the unit file before we deploy the application then the application won't start (like if it exits and systemd restarts it).

This PR adds the option back (and ignores it) so we can update the unit file at our leisure.