### PR TITLE
EVG-18048: Update logkeeper to accept "Execution" as build/test metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ logkeeperapp.log
 _bucketdata
 .DS_Store
 vendor/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ logkeeperapp.log
 _bucketdata
 .DS_Store
 vendor/
-

--- a/model/build.go
+++ b/model/build.go
@@ -17,10 +17,11 @@ const metadataFilename = "metadata.json"
 
 // Build contains metadata about a build.
 type Build struct {
-	ID       string `json:"id"`
-	Builder  string `json:"builder"`
-	BuildNum int    `json:"buildnum"`
-	TaskID   string `json:"task_id"`
+	ID            string `json:"id"`
+	Builder       string `json:"builder"`
+	BuildNum      int    `json:"buildnum"`
+	TaskID        string `json:"task_id"`
+	TaskExecution int    `json:"task_execution"`
 }
 
 // UploadMetadata uploads metadata for a new build to the pail-backed

--- a/model/build.go
+++ b/model/build.go
@@ -21,7 +21,7 @@ type Build struct {
 	Builder       string `json:"builder"`
 	BuildNum      int    `json:"buildnum"`
 	TaskID        string `json:"task_id"`
-	TaskExecution int    `json:"task_execution"`
+	TaskExecution int    `json:"execution"`
 }
 
 // UploadMetadata uploads metadata for a new build to the pail-backed

--- a/model/build_test.go
+++ b/model/build_test.go
@@ -77,7 +77,7 @@ func TestBuildToJSON(t *testing.T) {
 	}
 	data, err := build.toJSON()
 	require.NoError(t, err)
-	assert.JSONEq(t, `{"id":"b0","builder":"builder0","buildnum":1,"task_id":"t0","task_execution":1}`, string(data))
+	assert.JSONEq(t, `{"id":"b0","builder":"builder0","buildnum":1,"task_id":"t0","execution":1}`, string(data))
 }
 
 func TestCheckBuildMetadata(t *testing.T) {

--- a/model/build_test.go
+++ b/model/build_test.go
@@ -58,24 +58,26 @@ func TestUploadBuildMetadata(t *testing.T) {
 
 func TestBuildKey(t *testing.T) {
 	build := Build{
-		ID:       "b0",
-		Builder:  "builder0",
-		BuildNum: 1,
-		TaskID:   "t0",
+		ID:            "b0",
+		Builder:       "builder0",
+		BuildNum:      1,
+		TaskID:        "t0",
+		TaskExecution: 1,
 	}
 	assert.Equal(t, "builds/b0/metadata.json", build.key())
 }
 
 func TestBuildToJSON(t *testing.T) {
 	build := Build{
-		ID:       "b0",
-		Builder:  "builder0",
-		BuildNum: 1,
-		TaskID:   "t0",
+		ID:            "b0",
+		Builder:       "builder0",
+		BuildNum:      1,
+		TaskID:        "t0",
+		TaskExecution: 1,
 	}
 	data, err := build.toJSON()
 	require.NoError(t, err)
-	assert.JSONEq(t, `{"id":"b0","builder":"builder0","buildnum":1,"task_id":"t0"}`, string(data))
+	assert.JSONEq(t, `{"id":"b0","builder":"builder0","buildnum":1,"task_id":"t0","task_execution":1}`, string(data))
 }
 
 func TestCheckBuildMetadata(t *testing.T) {

--- a/model/test.go
+++ b/model/test.go
@@ -26,7 +26,7 @@ type Test struct {
 	Name          string `json:"name"`
 	BuildID       string `json:"build_id"`
 	TaskID        string `json:"task_id"`
-	TaskExecution int    `json:"task_execution"`
+	TaskExecution int    `json:"execution"`
 	Phase         string `json:"phase"`
 	Command       string `json:"command"`
 }

--- a/model/test.go
+++ b/model/test.go
@@ -22,12 +22,13 @@ import (
 
 // Test describes metadata of a test stored in pail-backed offline storage.
 type Test struct {
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	BuildID string `json:"build_id"`
-	TaskID  string `json:"task_id"`
-	Phase   string `json:"phase"`
-	Command string `json:"command"`
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	BuildID       string `json:"build_id"`
+	TaskID        string `json:"task_id"`
+	TaskExecution int    `json:"task_execution"`
+	Phase         string `json:"phase"`
+	Command       string `json:"command"`
 }
 
 // NewTestID returns a new TestID with it's timestamp set to startTime.

--- a/model/test_test.go
+++ b/model/test_test.go
@@ -39,12 +39,13 @@ func TestUploadTestMetadata(t *testing.T) {
 
 	defer testutil.SetBucket(t, "")()
 	test := Test{
-		ID:      "62dba0159041307f697e6ccc",
-		Name:    "test0",
-		BuildID: "5a75f537726934e4b62833ab6d5dca41",
-		TaskID:  "t0",
-		Phase:   "phase0",
-		Command: "command0",
+		ID:            "62dba0159041307f697e6ccc",
+		Name:          "test0",
+		BuildID:       "5a75f537726934e4b62833ab6d5dca41",
+		TaskID:        "t0",
+		TaskExecution: 1,
+		Phase:         "phase0",
+		Command:       "command0",
 	}
 	expectedData, err := test.toJSON()
 	require.NoError(t, err)
@@ -59,28 +60,30 @@ func TestUploadTestMetadata(t *testing.T) {
 
 func TestTestKey(t *testing.T) {
 	test := Test{
-		ID:      "test0",
-		Name:    "name",
-		BuildID: "build0",
-		TaskID:  "t0",
-		Phase:   "phase0",
-		Command: "command0",
+		ID:            "test0",
+		Name:          "name",
+		BuildID:       "build0",
+		TaskID:        "t0",
+		TaskExecution: 1,
+		Phase:         "phase0",
+		Command:       "command0",
 	}
 	assert.Equal(t, "builds/build0/tests/test0/metadata.json", test.key())
 }
 
 func TestTestToJSON(t *testing.T) {
 	test := Test{
-		ID:      "test0",
-		Name:    "name",
-		BuildID: "build0",
-		TaskID:  "t0",
-		Phase:   "phase0",
-		Command: "command0",
+		ID:            "test0",
+		Name:          "name",
+		BuildID:       "build0",
+		TaskID:        "t0",
+		TaskExecution: 1,
+		Phase:         "phase0",
+		Command:       "command0",
 	}
 	data, err := test.toJSON()
 	require.NoError(t, err)
-	assert.JSONEq(t, `{"id":"test0","name":"name","build_id":"build0","task_id":"t0","phase":"phase0","command":"command0"}`, string(data))
+	assert.JSONEq(t, `{"id":"test0","name":"name","build_id":"build0","task_id":"t0","task_execution":1,"phase":"phase0","command":"command0"}`, string(data))
 }
 
 func TestCheckTestMetadata(t *testing.T) {
@@ -139,12 +142,13 @@ func TestFindTestByID(t *testing.T) {
 	defer testutil.SetBucket(t, "../testdata/simple")()
 	t.Run("Exists", func(t *testing.T) {
 		expected := &Test{
-			ID:      "17046404de18d0000000000000000000",
-			BuildID: "5a75f537726934e4b62833ab6d5dca41",
-			Name:    "geo_max:CheckReplOplogs",
-			TaskID:  "mongodb_mongo_master_enterprise_rhel_80_64_bit_multiversion_all_feature_flags_retryable_writes_downgrade_last_continuous_2_enterprise_f98b3361fbab4e02683325cc0e6ebaa69d6af1df_22_07_22_11_24_37",
-			Phase:   "phase0",
-			Command: "command0",
+			ID:            "17046404de18d0000000000000000000",
+			BuildID:       "5a75f537726934e4b62833ab6d5dca41",
+			Name:          "geo_max:CheckReplOplogs",
+			TaskID:        "mongodb_mongo_master_enterprise_rhel_80_64_bit_multiversion_all_feature_flags_retryable_writes_downgrade_last_continuous_2_enterprise_f98b3361fbab4e02683325cc0e6ebaa69d6af1df_22_07_22_11_24_37",
+			TaskExecution: 1,
+			Phase:         "phase0",
+			Command:       "command0",
 		}
 		actual, err := FindTestByID(ctx, "5a75f537726934e4b62833ab6d5dca41", "17046404de18d0000000000000000000")
 		require.NoError(t, err)
@@ -167,20 +171,22 @@ func TestFindTestsForBuild(t *testing.T) {
 
 	expected := []Test{
 		{
-			ID:      "0de0b6b3bf4ac6400000000000000000",
-			BuildID: "5a75f537726934e4b62833ab6d5dca41",
-			Name:    "geo_max:CheckReplOplogs",
-			TaskID:  "Task",
-			Command: "command0",
-			Phase:   "phase0",
+			ID:            "0de0b6b3bf4ac6400000000000000000",
+			BuildID:       "5a75f537726934e4b62833ab6d5dca41",
+			Name:          "geo_max:CheckReplOplogs",
+			TaskID:        "Task",
+			TaskExecution: 1,
+			Command:       "command0",
+			Phase:         "phase0",
 		},
 		{
-			ID:      "0de0b6b3cb3688400000000000000000",
-			BuildID: "5a75f537726934e4b62833ab6d5dca41",
-			Name:    "geo_max:CheckReplOplogs2",
-			TaskID:  "Task",
-			Command: "command1",
-			Phase:   "phase1",
+			ID:            "0de0b6b3cb3688400000000000000000",
+			BuildID:       "5a75f537726934e4b62833ab6d5dca41",
+			Name:          "geo_max:CheckReplOplogs2",
+			TaskID:        "Task",
+			TaskExecution: 2,
+			Command:       "command1",
+			Phase:         "phase1",
 		},
 	}
 	testResponse, err := FindTestsForBuild(context.Background(), "5a75f537726934e4b62833ab6d5dca41")

--- a/model/test_test.go
+++ b/model/test_test.go
@@ -83,7 +83,7 @@ func TestTestToJSON(t *testing.T) {
 	}
 	data, err := test.toJSON()
 	require.NoError(t, err)
-	assert.JSONEq(t, `{"id":"test0","name":"name","build_id":"build0","task_id":"t0","task_execution":1,"phase":"phase0","command":"command0"}`, string(data))
+	assert.JSONEq(t, `{"id":"test0","name":"name","build_id":"build0","task_id":"t0","execution":1,"phase":"phase0","command":"command0"}`, string(data))
 }
 
 func TestCheckTestMetadata(t *testing.T) {

--- a/smoke/smoke_test.go
+++ b/smoke/smoke_test.go
@@ -24,7 +24,7 @@ var (
 		Builder       string `json:"builder"`
 		BuildNum      int    `json:"buildnum"`
 		TaskID        string `json:"task_id"`
-		TaskExecution int    `json:"task_execution"`
+		TaskExecution int    `json:"execution"`
 	}{
 		Builder:       "b0",
 		BuildNum:      rand.New(rand.NewSource(time.Now().UnixNano())).Int(),
@@ -37,7 +37,7 @@ var (
 		Command       string `json:"command"`
 		Phase         string `json:"phase"`
 		TaskID        string `json:"task_id"`
-		TaskExecution int    `json:"task_execution"`
+		TaskExecution int    `json:"execution"`
 	}{
 		TestFilename:  "f0",
 		Command:       "c0",
@@ -91,7 +91,7 @@ func createTest(buildID string) (string, error) {
 		"command":        "c0",
 		"phase":          "p0",
 		"task_id":        "t0",
-		"task_execution": 1,
+		"execution": 1,
 	})
 	resp, err := http.Post(fmt.Sprintf("http://localhost:%s/build/%s/test", port, buildID), "application/json", bytes.NewBuffer(body))
 	if err != nil {

--- a/smoke/smoke_test.go
+++ b/smoke/smoke_test.go
@@ -21,25 +21,29 @@ var port = os.Getenv("PORT")
 
 var (
 	sampleBuild = struct {
-		Builder  string `json:"builder"`
-		BuildNum int    `json:"buildnum"`
-		TaskID   string `json:"task_id"`
+		Builder       string `json:"builder"`
+		BuildNum      int    `json:"buildnum"`
+		TaskID        string `json:"task_id"`
+		TaskExecution int    `json:"task_execution"`
 	}{
-		Builder:  "b0",
-		BuildNum: rand.New(rand.NewSource(time.Now().UnixNano())).Int(),
-		TaskID:   "t0",
+		Builder:       "b0",
+		BuildNum:      rand.New(rand.NewSource(time.Now().UnixNano())).Int(),
+		TaskID:        "t0",
+		TaskExecution: 1,
 	}
 
 	sampleTest = struct {
-		TestFilename string `json:"test_filename"`
-		Command      string `json:"command"`
-		Phase        string `json:"phase"`
-		TaskID       string `json:"task_id"`
+		TestFilename  string `json:"test_filename"`
+		Command       string `json:"command"`
+		Phase         string `json:"phase"`
+		TaskID        string `json:"task_id"`
+		TaskExecution int    `json:"task_execution"`
 	}{
-		TestFilename: "f0",
-		Command:      "c0",
-		Phase:        "p0",
-		TaskID:       "t0",
+		TestFilename:  "f0",
+		Command:       "c0",
+		Phase:         "p0",
+		TaskID:        "t0",
+		TaskExecution: 1,
 	}
 
 	globalLogs = [][]interface{}{
@@ -83,10 +87,11 @@ func createBuild() (string, error) {
 
 func createTest(buildID string) (string, error) {
 	body, _ := json.Marshal(map[string]interface{}{
-		"test_filename": "f0",
-		"command":       "c0",
-		"phase":         "p0",
-		"task_id":       "t0",
+		"test_filename":  "f0",
+		"command":        "c0",
+		"phase":          "p0",
+		"task_id":        "t0",
+		"task_execution": 1,
 	})
 	resp, err := http.Post(fmt.Sprintf("http://localhost:%s/build/%s/test", port, buildID), "application/json", bytes.NewBuffer(body))
 	if err != nil {

--- a/testdata/between/builds/5a75f537726934e4b62833ab6d5dca41/tests/0de0b6b3bf4ac6400000000000000000/metadata.json
+++ b/testdata/between/builds/5a75f537726934e4b62833ab6d5dca41/tests/0de0b6b3bf4ac6400000000000000000/metadata.json
@@ -3,6 +3,7 @@
     "build_id": "5a75f537726934e4b62833ab6d5dca41",
     "name": "geo_max:CheckReplOplogs",
     "task_id": "Task",
+    "task_execution": 1,
     "phase": "phase0",
     "command": "command0"
 }

--- a/testdata/between/builds/5a75f537726934e4b62833ab6d5dca41/tests/0de0b6b3bf4ac6400000000000000000/metadata.json
+++ b/testdata/between/builds/5a75f537726934e4b62833ab6d5dca41/tests/0de0b6b3bf4ac6400000000000000000/metadata.json
@@ -3,7 +3,7 @@
     "build_id": "5a75f537726934e4b62833ab6d5dca41",
     "name": "geo_max:CheckReplOplogs",
     "task_id": "Task",
-    "task_execution": 1,
+    "execution": 1,
     "phase": "phase0",
     "command": "command0"
 }

--- a/testdata/between/builds/5a75f537726934e4b62833ab6d5dca41/tests/0de0b6b3cb3688400000000000000000/metadata.json
+++ b/testdata/between/builds/5a75f537726934e4b62833ab6d5dca41/tests/0de0b6b3cb3688400000000000000000/metadata.json
@@ -3,6 +3,7 @@
     "build_id": "5a75f537726934e4b62833ab6d5dca41",
     "name": "geo_max:CheckReplOplogs2",
     "task_id": "Task",
+    "task_execution": 2,
     "phase": "phase1",
     "command": "command1"
 }

--- a/testdata/between/builds/5a75f537726934e4b62833ab6d5dca41/tests/0de0b6b3cb3688400000000000000000/metadata.json
+++ b/testdata/between/builds/5a75f537726934e4b62833ab6d5dca41/tests/0de0b6b3cb3688400000000000000000/metadata.json
@@ -3,7 +3,7 @@
     "build_id": "5a75f537726934e4b62833ab6d5dca41",
     "name": "geo_max:CheckReplOplogs2",
     "task_id": "Task",
-    "task_execution": 2,
+    "execution": 2,
     "phase": "phase1",
     "command": "command1"
 }

--- a/testdata/delayed/builds/5a75f537726934e4b62833ab6d5dca41/tests/0de0b6b3bf3b84000000000000000000/metadata.json
+++ b/testdata/delayed/builds/5a75f537726934e4b62833ab6d5dca41/tests/0de0b6b3bf3b84000000000000000000/metadata.json
@@ -3,6 +3,7 @@
     "build_id": "5a75f537726934e4b62833ab6d5dca41",
     "name": "geo_max:CheckReplOplogs",
     "task_id": "Task",
+    "task_execution": 1,
     "phase": "phase0",
     "command": "command0"
 }

--- a/testdata/delayed/builds/5a75f537726934e4b62833ab6d5dca41/tests/0de0b6b3bf3b84000000000000000000/metadata.json
+++ b/testdata/delayed/builds/5a75f537726934e4b62833ab6d5dca41/tests/0de0b6b3bf3b84000000000000000000/metadata.json
@@ -3,7 +3,7 @@
     "build_id": "5a75f537726934e4b62833ab6d5dca41",
     "name": "geo_max:CheckReplOplogs",
     "task_id": "Task",
-    "task_execution": 1,
+    "execution": 1,
     "phase": "phase0",
     "command": "command0"
 }

--- a/testdata/nolines/builds/5a75f537726934e4b62833ab6d5dca41/tests/de0b6b3a764000000000000/metadata.json
+++ b/testdata/nolines/builds/5a75f537726934e4b62833ab6d5dca41/tests/de0b6b3a764000000000000/metadata.json
@@ -5,6 +5,6 @@
     "name": "geo_max:CheckReplOplogs",
     "command": "",
     "task_id": "Task",
-    "task_execution": 1,
+    "execution": 1,
     "phase": "phase"
 }

--- a/testdata/nolines/builds/5a75f537726934e4b62833ab6d5dca41/tests/de0b6b3a764000000000000/metadata.json
+++ b/testdata/nolines/builds/5a75f537726934e4b62833ab6d5dca41/tests/de0b6b3a764000000000000/metadata.json
@@ -5,5 +5,6 @@
     "name": "geo_max:CheckReplOplogs",
     "command": "",
     "task_id": "Task",
+    "task_execution": 1,
     "phase": "phase"
 }

--- a/testdata/overlapping/builds/5a75f537726934e4b62833ab6d5dca41/tests/0de0b6b3bf3b84000000000000000000/metadata.json
+++ b/testdata/overlapping/builds/5a75f537726934e4b62833ab6d5dca41/tests/0de0b6b3bf3b84000000000000000000/metadata.json
@@ -3,6 +3,7 @@
     "build_id": "5a75f537726934e4b62833ab6d5dca41",
     "name": "geo_max:CheckReplOplogs",
     "task_id": "Task",
+    "task_execution": 1,
     "phase": "phase0",
     "command": "command0"
 }

--- a/testdata/overlapping/builds/5a75f537726934e4b62833ab6d5dca41/tests/0de0b6b3bf3b84000000000000000000/metadata.json
+++ b/testdata/overlapping/builds/5a75f537726934e4b62833ab6d5dca41/tests/0de0b6b3bf3b84000000000000000000/metadata.json
@@ -3,7 +3,7 @@
     "build_id": "5a75f537726934e4b62833ab6d5dca41",
     "name": "geo_max:CheckReplOplogs",
     "task_id": "Task",
-    "task_execution": 1,
+    "execution": 1,
     "phase": "phase0",
     "command": "command0"
 }

--- a/testdata/precision/builds/5a75f537726934e4b62833ab6d5dca41/tests/17046404de28123f0000000000000000/metadata.json
+++ b/testdata/precision/builds/5a75f537726934e4b62833ab6d5dca41/tests/17046404de28123f0000000000000000/metadata.json
@@ -3,6 +3,7 @@
     "build_id": "5a75f537726934e4b62833ab6d5dca41",
     "name": "geo_max:CheckReplOplogs",
     "task_id": "mongodb_mongo_master_enterprise_rhel_80_64_bit_multiversion_all_feature_flags_retryable_writes_downgrade_last_continuous_2_enterprise_f98b3361fbab4e02683325cc0e6ebaa69d6af1df_22_07_22_11_24_37",
+    "task_execution": 1,
     "phase": "phase0",
     "command": "command0"
 }

--- a/testdata/precision/builds/5a75f537726934e4b62833ab6d5dca41/tests/17046404de28123f0000000000000000/metadata.json
+++ b/testdata/precision/builds/5a75f537726934e4b62833ab6d5dca41/tests/17046404de28123f0000000000000000/metadata.json
@@ -3,7 +3,7 @@
     "build_id": "5a75f537726934e4b62833ab6d5dca41",
     "name": "geo_max:CheckReplOplogs",
     "task_id": "mongodb_mongo_master_enterprise_rhel_80_64_bit_multiversion_all_feature_flags_retryable_writes_downgrade_last_continuous_2_enterprise_f98b3361fbab4e02683325cc0e6ebaa69d6af1df_22_07_22_11_24_37",
-    "task_execution": 1,
+    "execution": 1,
     "phase": "phase0",
     "command": "command0"
 }

--- a/testdata/simple/builds/5a75f537726934e4b62833ab6d5dca41/tests/17046404de18d0000000000000000000/metadata.json
+++ b/testdata/simple/builds/5a75f537726934e4b62833ab6d5dca41/tests/17046404de18d0000000000000000000/metadata.json
@@ -3,6 +3,7 @@
     "build_id": "5a75f537726934e4b62833ab6d5dca41",
     "name": "geo_max:CheckReplOplogs",
     "task_id": "mongodb_mongo_master_enterprise_rhel_80_64_bit_multiversion_all_feature_flags_retryable_writes_downgrade_last_continuous_2_enterprise_f98b3361fbab4e02683325cc0e6ebaa69d6af1df_22_07_22_11_24_37",
+    "task_execution": 1,
     "phase": "phase0",
     "command": "command0"
 }

--- a/testdata/simple/builds/5a75f537726934e4b62833ab6d5dca41/tests/17046404de18d0000000000000000000/metadata.json
+++ b/testdata/simple/builds/5a75f537726934e4b62833ab6d5dca41/tests/17046404de18d0000000000000000000/metadata.json
@@ -3,7 +3,7 @@
     "build_id": "5a75f537726934e4b62833ab6d5dca41",
     "name": "geo_max:CheckReplOplogs",
     "task_id": "mongodb_mongo_master_enterprise_rhel_80_64_bit_multiversion_all_feature_flags_retryable_writes_downgrade_last_continuous_2_enterprise_f98b3361fbab4e02683325cc0e6ebaa69d6af1df_22_07_22_11_24_37",
-    "task_execution": 1,
+    "execution": 1,
     "phase": "phase0",
     "command": "command0"
 }

--- a/views.go
+++ b/views.go
@@ -144,9 +144,10 @@ func (lk *logkeeper) createBuild(w http.ResponseWriter, r *http.Request) {
 	}
 
 	payload := struct {
-		Builder  string `json:"builder"`
-		BuildNum int    `json:"buildnum"`
-		TaskID   string `json:"task_id"`
+		Builder       string `json:"builder"`
+		BuildNum      int    `json:"buildnum"`
+		TaskID        string `json:"task_id"`
+		TaskExecution int    `json:"task_execution"`
 	}{}
 	if err := readJSON(r.Body, lk.opts.MaxRequestSize, &payload); err != nil {
 		lk.logErrorf(r, "bad request to create build: %s", err.Err)
@@ -170,10 +171,11 @@ func (lk *logkeeper) createBuild(w http.ResponseWriter, r *http.Request) {
 	}
 	if !exists {
 		build := model.Build{
-			ID:       id,
-			Builder:  payload.Builder,
-			BuildNum: payload.BuildNum,
-			TaskID:   payload.TaskID,
+			ID:            id,
+			Builder:       payload.Builder,
+			BuildNum:      payload.BuildNum,
+			TaskID:        payload.TaskID,
+			TaskExecution: payload.TaskExecution,
 		}
 		if err = build.UploadMetadata(r.Context()); err != nil {
 			lk.logErrorf(r, "uploading build metadata: %v", err)
@@ -203,10 +205,11 @@ func (lk *logkeeper) createTest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	payload := struct {
-		TestFilename string `json:"test_filename"`
-		Command      string `json:"command"`
-		Phase        string `json:"phase"`
-		TaskID       string `json:"task_id"`
+		TestFilename  string `json:"test_filename"`
+		Command       string `json:"command"`
+		Phase         string `json:"phase"`
+		TaskID        string `json:"task_id"`
+		TaskExecution int    `json:"task_execution"`
 	}{}
 	if err := readJSON(r.Body, lk.opts.MaxRequestSize, &payload); err != nil {
 		lk.logErrorf(r, "bad request to create test for build '%s': %s", buildID, err.Err)
@@ -226,12 +229,13 @@ func (lk *logkeeper) createTest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	test := model.Test{
-		ID:      model.NewTestID(time.Now()),
-		Name:    payload.TestFilename,
-		BuildID: buildID,
-		TaskID:  payload.TaskID,
-		Phase:   payload.Phase,
-		Command: payload.Command,
+		ID:            model.NewTestID(time.Now()),
+		Name:          payload.TestFilename,
+		BuildID:       buildID,
+		TaskID:        payload.TaskID,
+		TaskExecution: payload.TaskExecution,
+		Phase:         payload.Phase,
+		Command:       payload.Command,
 	}
 	if err = test.UploadTestMetadata(r.Context()); err != nil {
 		lk.logErrorf(r, "uploading test metadata for build '%s': %v", buildID, err)
@@ -501,13 +505,14 @@ func (lk *logkeeper) viewTestLogs(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		err := lk.render.StreamHTML(w, http.StatusOK, struct {
-			LogLines chan *model.LogLineItem
-			BuildID  string
-			Builder  string
-			TestID   string
-			TestName string
-			TaskID   string
-		}{resp.logLines, resp.build.ID, resp.build.Builder, resp.test.ID, resp.test.Name, resp.test.TaskID}, "base", "test.html")
+			LogLines      chan *model.LogLineItem
+			BuildID       string
+			Builder       string
+			TestID        string
+			TestName      string
+			TaskID        string
+			TaskExecution int
+		}{resp.logLines, resp.build.ID, resp.build.Builder, resp.test.ID, resp.test.Name, resp.test.TaskID, resp.build.TaskExecution}, "base", "test.html")
 		if err != nil {
 			lk.logErrorf(r, "rendering template: %v", err)
 		}

--- a/views.go
+++ b/views.go
@@ -147,7 +147,7 @@ func (lk *logkeeper) createBuild(w http.ResponseWriter, r *http.Request) {
 		Builder       string `json:"builder"`
 		BuildNum      int    `json:"buildnum"`
 		TaskID        string `json:"task_id"`
-		TaskExecution int    `json:"task_execution"`
+		TaskExecution int    `json:"execution"`
 	}{}
 	if err := readJSON(r.Body, lk.opts.MaxRequestSize, &payload); err != nil {
 		lk.logErrorf(r, "bad request to create build: %s", err.Err)
@@ -209,7 +209,7 @@ func (lk *logkeeper) createTest(w http.ResponseWriter, r *http.Request) {
 		Command       string `json:"command"`
 		Phase         string `json:"phase"`
 		TaskID        string `json:"task_id"`
-		TaskExecution int    `json:"task_execution"`
+		TaskExecution int    `json:"execution"`
 	}{}
 	if err := readJSON(r.Body, lk.opts.MaxRequestSize, &payload); err != nil {
 		lk.logErrorf(r, "bad request to create test for build '%s': %s", buildID, err.Err)

--- a/views_test.go
+++ b/views_test.go
@@ -273,10 +273,11 @@ func TestCreateTest(t *testing.T) {
 			}),
 			buildID: buildID,
 			input: &payload{
-				TestFilename: "test",
-				Command:      "command",
-				Phase:        "phase",
-				TaskID:       "id",
+				TestFilename:  "test",
+				Command:       "command",
+				Phase:         "phase",
+				TaskID:        "id",
+				TaskExecution: 10,
 			},
 			expectedStatusCode: http.StatusCreated,
 			test: func(t *testing.T, resp *httptest.ResponseRecorder) {
@@ -291,6 +292,7 @@ func TestCreateTest(t *testing.T) {
 				assert.Equal(t, "test", test.Name)
 				assert.Equal(t, buildID, test.BuildID)
 				assert.Equal(t, "id", test.TaskID)
+				assert.Equal(t, 10, test.TaskExecution)
 				assert.Equal(t, "phase", test.Phase)
 				assert.Equal(t, "command", test.Command)
 			},
@@ -314,7 +316,6 @@ func TestAppendGlobalLog(t *testing.T) {
 		name               string
 		lk                 *logkeeper
 		buildID            string
-		taskExecution      int
 		chunks             []interface{}
 		expectedStatusCode int
 		test               func(*testing.T, *httptest.ResponseRecorder, []interface{})

--- a/views_test.go
+++ b/views_test.go
@@ -58,9 +58,10 @@ func TestCreateBuild(t *testing.T) {
 	defer testutil.SetBucket(t, "")()
 
 	type payload struct {
-		Builder  string `json:"builder"`
-		BuildNum int    `json:"buildnum"`
-		TaskID   string `json:"task_id"`
+		Builder       string `json:"builder"`
+		BuildNum      int    `json:"buildnum"`
+		TaskID        string `json:"task_id"`
+		TaskExecution int    `json:"execution"`
 	}
 	for _, test := range []struct {
 		name               string
@@ -77,9 +78,10 @@ func TestCreateBuild(t *testing.T) {
 				MaxRequestSize: 10,
 			}),
 			input: &payload{
-				Builder:  "builder",
-				BuildNum: 10,
-				TaskID:   "id",
+				Builder:       "builder",
+				BuildNum:      10,
+				TaskID:        "id",
+				TaskExecution: 1,
 			},
 			expectedStatusCode: http.StatusRequestEntityTooLarge,
 			test: func(t *testing.T, resp *httptest.ResponseRecorder) {
@@ -111,9 +113,10 @@ func TestCreateBuild(t *testing.T) {
 				MaxRequestSize: testMaxReqSize,
 			}),
 			input: &payload{
-				Builder:  "builder",
-				BuildNum: 10,
-				TaskID:   "id",
+				Builder:       "builder",
+				BuildNum:      10,
+				TaskID:        "id",
+				TaskExecution: 1,
 			},
 			expectedStatusCode: http.StatusCreated,
 			test: func(t *testing.T, resp *httptest.ResponseRecorder) {
@@ -131,6 +134,7 @@ func TestCreateBuild(t *testing.T) {
 				assert.Equal(t, "builder", build.Builder)
 				assert.Equal(t, 10, build.BuildNum)
 				assert.Equal(t, "id", build.TaskID)
+				assert.Equal(t, 1, build.TaskExecution)
 			},
 		},
 		{
@@ -140,19 +144,21 @@ func TestCreateBuild(t *testing.T) {
 				MaxRequestSize: testMaxReqSize,
 			}),
 			input: &payload{
-				Builder:  "existing",
-				BuildNum: 150,
-				TaskID:   "id",
+				Builder:       "existing",
+				BuildNum:      150,
+				TaskID:        "id",
+				TaskExecution: 1,
 			},
 			expectedStatusCode: http.StatusOK,
 			setup: func(t *testing.T) {
 				id, err := model.NewBuildID("existing", 150)
 				require.NoError(t, err)
 				build := model.Build{
-					ID:       id,
-					Builder:  "existing",
-					BuildNum: 150,
-					TaskID:   "id",
+					ID:            id,
+					Builder:       "existing",
+					BuildNum:      150,
+					TaskID:        "id",
+					TaskExecution: 1,
 				}
 				require.NoError(t, build.UploadMetadata(context.TODO()))
 			},
@@ -184,15 +190,17 @@ func TestCreateTest(t *testing.T) {
 
 	buildID := "5a75f537726934e4b62833ab6d5dca41"
 	type payload struct {
-		TestFilename string `json:"test_filename"`
-		Command      string `json:"command"`
-		Phase        string `json:"phase"`
-		TaskID       string `json:"task_id"`
+		TestFilename  string `json:"test_filename"`
+		Command       string `json:"command"`
+		Phase         string `json:"phase"`
+		TaskID        string `json:"task_id"`
+		TaskExecution int    `json:"execution"`
 	}
 	for _, test := range []struct {
 		name               string
 		lk                 *logkeeper
 		buildID            string
+		taskExecution      int
 		input              interface{}
 		expectedStatusCode int
 		test               func(*testing.T, *httptest.ResponseRecorder)
@@ -205,10 +213,11 @@ func TestCreateTest(t *testing.T) {
 			}),
 			buildID: buildID,
 			input: &payload{
-				TestFilename: "test",
-				Command:      "command",
-				Phase:        "phase",
-				TaskID:       "task",
+				TestFilename:  "test",
+				Command:       "command",
+				Phase:         "phase",
+				TaskID:        "task",
+				TaskExecution: 10,
 			},
 			expectedStatusCode: http.StatusRequestEntityTooLarge,
 			test: func(t *testing.T, resp *httptest.ResponseRecorder) {
@@ -242,10 +251,11 @@ func TestCreateTest(t *testing.T) {
 			}),
 			buildID: "DNE",
 			input: &payload{
-				TestFilename: "test",
-				Command:      "command",
-				Phase:        "phase",
-				TaskID:       "task",
+				TestFilename:  "test",
+				Command:       "command",
+				Phase:         "phase",
+				TaskID:        "task",
+				TaskExecution: 10,
 			},
 			expectedStatusCode: http.StatusNotFound,
 			test: func(t *testing.T, resp *httptest.ResponseRecorder) {
@@ -304,6 +314,7 @@ func TestAppendGlobalLog(t *testing.T) {
 		name               string
 		lk                 *logkeeper
 		buildID            string
+		taskExecution      int
 		chunks             []interface{}
 		expectedStatusCode int
 		test               func(*testing.T, *httptest.ResponseRecorder, []interface{})


### PR DESCRIPTION
This patch allows for the inclusion of a `task_execution` parameter to be sent to logkeeper as metadata. It is an int.