### PR TITLE
EVG-17910: Set response logger std dev to 0 when sample size is 1

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -261,12 +261,21 @@ func sliceStats(sample, histogramBins []float64) message.Fields {
 		return message.Fields{}
 	}
 
+	// Only calculate the standard deviation if the sample size is greater
+	// than 1, otherwise set it to 0. This avoids setting the field to NaN,
+	// which cannot be marshalled into JSON, and ensures that all of the
+	// stats logs are written correctly to Splunk.
+	var stdDev float64
+	if len(sample) > 1 {
+		stdDev = stat.StdDev(sample, nil)
+	}
+
 	return message.Fields{
 		"sum":       floats.Sum(sample),
 		"min":       min,
 		"max":       max,
 		"mean":      stat.Mean(sample, nil),
-		"std_dev":   stat.StdDev(sample, nil),
+		"std_dev":   stdDev,
 		"histogram": stat.Histogram(nil, histogramBins, sample, nil),
 	}
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -30,8 +30,12 @@ func TestResponseLoggerLoop(t *testing.T) {
 		msg := sender.Messages[0].Raw().(message.Fields)
 		assert.Equal(t, "test_route", msg["route"])
 		assert.Equal(t, 1, msg["count"])
-	})
 
+		// Check that we properly set std dev.
+		serviceTimeStats, ok := msg["service_time_ms"].(message.Fields)
+		require.True(t, ok)
+		assert.Zero(t, serviceTimeStats["std_dev"])
+	})
 	t.Run("MultipleResponses", func(t *testing.T) {
 		sender := send.NewMockSender("")
 		require.NoError(t, grip.SetSender(sender))
@@ -48,8 +52,12 @@ func TestResponseLoggerLoop(t *testing.T) {
 		msg := sender.Messages[0].Raw().(message.Fields)
 		assert.Equal(t, "test_route", msg["route"])
 		assert.Equal(t, 3, msg["count"])
-	})
 
+		// Check that we properly set std dev.
+		serviceTimeStats, ok := msg["service_time_ms"].(message.Fields)
+		require.True(t, ok)
+		assert.NotZero(t, serviceTimeStats["std_dev"])
+	})
 	t.Run("MultipleRoutes", func(t *testing.T) {
 		sender := send.NewMockSender("")
 		require.NoError(t, grip.SetSender(sender))


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-17910

This avoids setting the std dev to NaN, which cannot be marshalled to JSON in the Splunk sender.