### PR TITLE
EVG-18291: Create a view build metadata route

### DIFF
--- a/views.go
+++ b/views.go
@@ -365,6 +365,15 @@ func (lk *logkeeper) viewBuild(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.FormValue("metadata") == "true" {
+		payload := struct {
+			model.Build
+			Tests []model.Test `json:"tests"`
+		}{*build, tests}
+		lk.render.WriteJSON(w, http.StatusOK, payload)
+		return
+	}
+
 	lk.render.WriteHTML(w, http.StatusOK, struct {
 		Build *model.Build
 		Tests []model.Test
@@ -481,7 +490,7 @@ func (lk *logkeeper) viewTestLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.FormValue("metadata") == "true" {
-		lk.render.WriteJSON(w, http.StatusOK, resp.build)
+		lk.render.WriteJSON(w, http.StatusOK, resp.test)
 		return
 	}
 

--- a/views_test.go
+++ b/views_test.go
@@ -785,6 +785,7 @@ func TestViewAllLogs(t *testing.T) {
 				require.NoError(t, err)
 
 				expectedOut, err := json.MarshalIndent(build, "", "  ")
+				require.NoError(t, err)
 				assert.Equal(t, expectedOut, resp.Body.Bytes())
 			},
 		},
@@ -924,6 +925,7 @@ func TestViewTestLogs(t *testing.T) {
 				require.NoError(t, err)
 
 				expectedOut, err := json.MarshalIndent(test, "", "  ")
+				require.NoError(t, err)
 				assert.Equal(t, expectedOut, resp.Body.Bytes())
 			},
 		},


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-18291

- Add a `metadata` parameter to the existing `/build/{build_id}` route that returns the build and test metadata as JSON.
- Return the test metadata instead of the build metadata for the `build/{build_id}/test/{test_id}` route.
- Add tests for all of the metadata routes.