### PR TITLE
EVG-18316 switch List to Get

### DIFF
--- a/model/build.go
+++ b/model/build.go
@@ -114,19 +114,15 @@ func checkMetadata(ctx context.Context, buildID string, testID string) (bool, er
 		key = metadataKeyForTest(buildID, testID)
 	}
 
-	iter, err := env.Bucket().List(ctx, key)
+	_, err := env.Bucket().Get(ctx, key)
 	if err != nil {
-		return false, errors.Wrap(err, "listing metadata files")
+		if pail.IsKeyNotFoundError(err) {
+			return false, nil
+		}
+		return false, errors.Wrap(err, "getting metadata file")
 	}
 
-	for iter.Next(ctx) {
-		// We set the prefix to the entire metadata filename, so
-		// finding a single file in the bucket with the given prefix
-		// suffices.
-		return true, nil
-	}
-
-	return false, errors.Wrap(iter.Err(), "iterating metadata files")
+	return true, nil
 }
 
 // getBuildKeys returns the all the keys contained within the build prefix.

--- a/model/build_test.go
+++ b/model/build_test.go
@@ -82,13 +82,18 @@ func TestBuildToJSON(t *testing.T) {
 
 func TestCheckBuildMetadata(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	defer cancel()
 
 	defer testutil.SetBucket(t, "../testdata/simple")()
 
-	t.Run("ServerError", func(t *testing.T) {
+	t.Run("MetadataExists", func(t *testing.T) {
 		exists, err := CheckBuildMetadata(ctx, "5a75f537726934e4b62833ab6d5dca41")
-		require.Error(t, err)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+	t.Run("NonexistentBuild", func(t *testing.T) {
+		exists, err := CheckBuildMetadata(ctx, "DOA")
+		require.NoError(t, err)
 		assert.False(t, exists)
 	})
 }


### PR DESCRIPTION
[EVG-18316](https://jira.mongodb.org/browse/EVG-18316)

List operations are 10x more expensive than Get operations (per [the docs](https://aws.amazon.com/s3/pricing/)).
In the short term let's switch the List to a Get. Afterwards it probably makes sense to add a [HeadObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html) to pail.