### PR TITLE
EVG-18629 unmarshal log lines directly

### DIFF
--- a/model/log.go
+++ b/model/log.go
@@ -75,7 +75,12 @@ func UnmarshalLogJSON(r io.Reader) ([]LogLineItem, error) {
 		return lines, errors.New("reading closing bracket")
 	}
 	if delim, ok := lastToken.(json.Delim); !ok || delim != ']' {
-		return lines, errors.Errorf("unexpected last token of type '%T', '%v'", lastToken, lastToken)
+		return lines, errors.Errorf("unexpected last token '%v' of type '%T'", lastToken, lastToken)
+	}
+
+	nextToken, err := dec.Token()
+	if err != io.EOF {
+		return lines, errors.Errorf("expected end of file, got '%v', type '%T'", nextToken, nextToken)
 	}
 
 	return lines, nil

--- a/model/log.go
+++ b/model/log.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"regexp"
 	"sort"
@@ -14,8 +15,6 @@ import (
 
 	"github.com/evergreen-ci/logkeeper/env"
 	"github.com/evergreen-ci/utility"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -28,33 +27,58 @@ type LogLineItem struct {
 	Global    bool
 }
 
-// UnmarshalJSON implements the json.Unmarshaler interface.
-func (ll *LogLineItem) UnmarshalJSON(data []byte) error {
-	var line []interface{}
-	if err := json.Unmarshal(data, &line); err != nil {
-		return errors.Wrap(err, "unmarshaling line into array")
+// UnmarshalLogJSON unmarshals log lines from JSON into a slice of LogLineItem.
+// Unmarshalling directly is more efficient than implementing the Unmarshaller interface.
+func UnmarshalLogJSON(r io.Reader) ([]LogLineItem, error) {
+	var lines []LogLineItem
+
+	dec := json.NewDecoder(r)
+	firstToken, err := dec.Token()
+	if err != nil {
+		return lines, errors.New("reading opening bracket")
+	}
+	if delim, ok := firstToken.(json.Delim); !ok || delim != '[' {
+		return lines, errors.Errorf("unexpected first token '%v' of type '%T'", firstToken, firstToken)
 	}
 
-	// timeField is generated client-side as the output of Python's
-	// time.time(), which returns seconds since epoch as a floating point
-	// number.
-	timeField, ok := line[0].(float64)
-	if !ok {
-		grip.Critical(message.Fields{
-			"message": "unable to convert time field",
-			"value":   line[0],
+	for dec.More() {
+		var line []interface{}
+		if err := dec.Decode(&line); err != nil {
+			return nil, errors.Wrap(err, "decoding line")
+		}
+		if len(line) != 2 {
+			return lines, errors.Errorf("line had unexpected number of elements %d", len(line))
+		}
+
+		timestamp, ok := line[0].(float64)
+		if !ok {
+			return lines, errors.Errorf("unexpected timestamp token '%v' of type '%v'", line[0], line[0])
+		}
+		data, ok := line[1].(string)
+		if !ok {
+			return lines, errors.Errorf("unexpected data token '%v' of type '%v'", line[1], line[1])
+		}
+
+		// Extract fractional seconds from the total time and convert to
+		// nanoseconds.
+		fractionalPart := timestamp - math.Floor(timestamp)
+		nSecPart := int64(fractionalPart * float64(int64(time.Second)/int64(time.Nanosecond)))
+
+		lines = append(lines, LogLineItem{
+			Timestamp: time.Unix(int64(timestamp), nSecPart),
+			Data:      data,
 		})
-		timeField = float64(time.Now().Unix())
 	}
-	// Extract fractional seconds from the total time and convert to
-	// nanoseconds.
-	fractionalPart := timeField - math.Floor(timeField)
-	nSecPart := int64(fractionalPart * float64(int64(time.Second)/int64(time.Nanosecond)))
 
-	ll.Timestamp = time.Unix(int64(timeField), nSecPart)
-	ll.Data = line[1].(string)
+	lastToken, err := dec.Token()
+	if err != nil {
+		return lines, errors.New("reading closing bracket")
+	}
+	if delim, ok := lastToken.(json.Delim); !ok || delim != ']' {
+		return lines, errors.Errorf("unexpected last token of type '%T', '%v'", lastToken, lastToken)
+	}
 
-	return nil
+	return lines, nil
 }
 
 // LoggerName returns the logger name for this line so it can be assigned a
@@ -131,7 +155,7 @@ func groupLines(lines []LogLineItem, maxSize int) ([]LogChunk, error) {
 	logChars := 0
 	for _, line := range lines {
 		if len(line.Data) > maxSize {
-			return nil, errors.New("Log line exceeded 4MB")
+			return nil, errors.Errorf("Log line exceeded %d bytes", maxSize)
 		}
 
 		if len(line.Data)+logChars > maxSize {
@@ -162,7 +186,7 @@ func InsertLogLines(ctx context.Context, buildID string, testID string, lines []
 
 	chunks, err := groupLines(lines, maxSize)
 	if err != nil {
-		return errors.Errorf("grouping lines for build '%s' test '%s'", buildID, testID)
+		return errors.Wrapf(err, "grouping lines for build '%s' test '%s'", buildID, testID)
 	}
 
 	for _, chunk := range chunks {

--- a/model/log.go
+++ b/model/log.go
@@ -80,6 +80,9 @@ func UnmarshalLogJSON(r io.Reader) ([]LogLineItem, error) {
 
 	nextToken, err := dec.Token()
 	if err != io.EOF {
+		if err != nil {
+			return lines, errors.Wrap(err, "getting EOF")
+		}
 		return lines, errors.Errorf("expected end of file, got '%v', type '%T'", nextToken, nextToken)
 	}
 

--- a/model/log_test.go
+++ b/model/log_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/evergreen-ci/logkeeper/env"
 	"github.com/evergreen-ci/logkeeper/testutil"
+	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,6 +23,41 @@ func TestUnmarshalJSON(t *testing.T) {
 	assert.NoError(t, json.Unmarshal([]byte(logLineJSON), &line))
 	assert.True(t, line.Timestamp.Equal(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)))
 	assert.Equal(t, "message", line.Data)
+}
+
+func TestReadLogJSON(t *testing.T) {
+	t.Run("EmptyLines", func(t *testing.T) {
+		lines, err := UnmarshalLogJSON(strings.NewReader(""))
+		assert.Error(t, err)
+		require.Len(t, lines, 0)
+	})
+
+	t.Run("WellFormedLines", func(t *testing.T) {
+		logLineJSON := "[[1257894000, \"message0\"],[1257894001, \"message1\"]]"
+		lines, err := UnmarshalLogJSON(strings.NewReader(logLineJSON))
+		assert.NoError(t, err)
+		require.Len(t, lines, 2)
+		assert.Equal(t, "message0", lines[0].Data)
+		assert.Equal(t, "message1", lines[1].Data)
+	})
+
+	t.Run("MalformedJSON", func(t *testing.T) {
+		logLineJSON := "[[1257894000, \"message0\"]}"
+		_, err := UnmarshalLogJSON(strings.NewReader(logLineJSON))
+		assert.Error(t, err)
+	})
+
+	t.Run("UnexpectedTimestampType", func(t *testing.T) {
+		logLineJSON := "[[\"not a date\", \"message0\"]]"
+		_, err := UnmarshalLogJSON(strings.NewReader(logLineJSON))
+		assert.Error(t, err)
+	})
+
+	t.Run("UnexpectedDataType", func(t *testing.T) {
+		logLineJSON := "[[1257894000, true]]"
+		_, err := UnmarshalLogJSON(strings.NewReader(logLineJSON))
+		assert.Error(t, err)
+	})
 }
 
 func TestLogChunkInfoKey(t *testing.T) {
@@ -422,3 +459,30 @@ func verifyDataStorage(t *testing.T, prefix string, expectedStorage expectedChun
 	require.NoError(t, err)
 	assert.Equal(t, expectedStorage.body, string(actualChunkBody))
 }
+
+func benchmarkReadLogJSON(lineCount, lineSize int, b *testing.B) {
+	sampleJSON := makeJSONSample(lineCount, lineSize)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		UnmarshalLogJSON(bytes.NewReader(sampleJSON))
+	}
+}
+
+func makeJSONSample(lineCount, lineSize int) []byte {
+	var sample [][]interface{}
+	startTime := time.Date(2009, time.November, 10, 23, 0, 0, 1, time.UTC)
+	for i := 0; i < lineCount; i++ {
+		sample = append(sample, []interface{}{
+			utility.ToPythonTime(startTime.Add(time.Duration(i) * time.Second)),
+			utility.MakeRandomString(lineSize),
+		})
+	}
+
+	jsonSample, _ := json.Marshal(sample)
+
+	return jsonSample
+}
+
+func BenchmarkReadLogJSONShort(b *testing.B)          { benchmarkReadLogJSON(100, 100, b) }
+func BenchmarkReadLogJSONFewLongLines(b *testing.B)   { benchmarkReadLogJSON(100, 100000, b) }
+func BenchmarkReadLogJSONManyShortLines(b *testing.B) { benchmarkReadLogJSON(100000, 100, b) }

--- a/model/log_test.go
+++ b/model/log_test.go
@@ -472,7 +472,7 @@ func benchmarkReadLogJSON(lineCount, lineSize int, b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, err := UnmarshalLogJSON(bytes.NewReader(sampleJSON))
 		if err != nil {
-			b.Fatalf("unmarshal encountered error %s", err)
+			b.Fatalf("unmarshal encountered error: '%s'", err)
 		}
 	}
 }

--- a/model/log_test.go
+++ b/model/log_test.go
@@ -58,6 +58,12 @@ func TestUnmarshalLogJSON(t *testing.T) {
 		_, err := UnmarshalLogJSON(strings.NewReader(logLineJSON))
 		assert.Error(t, err)
 	})
+
+	t.Run("UnexpectedExtraArray", func(t *testing.T) {
+		logLineJSON := "[[1257894000, \"message0\"]], [\"unexpected\"]"
+		_, err := UnmarshalLogJSON(strings.NewReader(logLineJSON))
+		assert.Error(t, err)
+	})
 }
 
 func TestLogChunkInfoKey(t *testing.T) {

--- a/requests.go
+++ b/requests.go
@@ -14,7 +14,7 @@ var ErrReadSizeLimitExceeded = errors.New("read size limit exceeded")
 // A LimitedReader reads from R but limits the amount of
 // data returned to just N bytes. Each call to Read
 // updates N to reflect the new amount remaining.
-// Note: this is identical to io.LimitedReader, but throws ErrReadSizeLimitExceeded
+// Note: this is identical to io.LimitedReader, but returns ErrReadSizeLimitExceeded
 // so it can be distinguished from a normal EOF.
 type LimitedReader struct {
 	R io.Reader // underlying reader


### PR DESCRIPTION
[EVG-18629](https://jira.mongodb.org/browse/EVG-18629)

It appears that unmarshaling by using the decoder directly (as in [this example](https://pkg.go.dev/encoding/json#example-Decoder.Decode-Stream)) uses about half the time and an order of magnitude less memory/fewer allocations.
From inspection of the CPU profiles, (with sufficient handwaving) it could be the reason is that when we were calling the regular json.Unmarshal that called into the custom unmarshaler we were having it do double the work: the custom marshaler called back out to the json library to parse a new byte array for the inner array. At the same time the original call to the json library also needed to parse the inner array to keep track of where we were up to.

The before and after is striking:
before
```
go test -run=XXX -bench=. -benchmem  github.com/evergreen-ci/logkeeper/model
goos: darwin
goarch: arm64
pkg: github.com/evergreen-ci/logkeeper/model
BenchmarkReadLogJSONShort-10                        4248            283256 ns/op          210539 B/op       1233 allocs/op
BenchmarkReadLogJSONFewLongLines-10                    6         168763653 ns/op        139885874 B/op      2043 allocs/op
BenchmarkReadLogJSONManyShortLines-10                  5         244760442 ns/op        212711104 B/op   1200077 allocs/op
```

after
```
go test -run=XXX -bench=. -benchmem  github.com/evergreen-ci/logkeeper/model                                               
goos: darwin
goarch: arm64
pkg: github.com/evergreen-ci/logkeeper/model
BenchmarkReadLogJSONShort-10                        9276            127900 ns/op           50680 B/op        715 allocs/op
BenchmarkReadLogJSONFewLongLines-10                   14          76477333 ns/op        21030074 B/op        722 allocs/op
BenchmarkReadLogJSONManyShortLines-10                  9         120494009 ns/op        61725290 B/op     700036 allocs/op
```

It's entirely possible we could get even better, but this is definitely a good first step.